### PR TITLE
Keys and clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 universal search desktop experiments in addon format
 
 Installation / how to hack on this?
-- `npm install` puts jpm inside your node_modules, or you can install it globally
-- ...
-- profit
-
-Some helpful jpm commands:
-- Build the extension: `./node_modules/.bin/jpm xpi`
-- Launch a Firefox instance with the extension installed: `./node_modules/.bin/jpm run`
+- you have to put a proxy file inside your local FF extensions directory, pointing to the absolute path to this code.
+  See MDN for more: https://developer.mozilla.org/en-US/Add-ons/Setting_up_extension_development_environment#Firefox_extension_proxy_file
+- TBD: does the proxy file detect changes in the addon source code? not sure yet.

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,82 +1,29 @@
-
 'use strict';
 
-// TODO require is undefined?
-// var {Cc, Ci, Cu} = require("chrome");
-//Cu.import("resource://gre/modules/Services.jsm");
-//Cu.import("resource://gre/modules/WebChannel.jsm");
+const { classes: Cc, interfaces: Ci, utils: Cu, manager: Cm } = Components;
 
-function install() {
-  console.log('installing');
-}
-function uninstall() {
-  console.log('uninstalling');
-}
+Cu.import('resource://gre/modules/XPCOMUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'Main',
+  'chrome://universalsearch-lib/content/main.js');
 
-// startup is called:
-// - when extension is first installed (assuming it's enabled)
-// - when extension becomes enabled via addons window
-// - when FF starts, if the extension is enabled
 function startup(data, reason) {
-  // define the app namespace
-  window.UNIVSEARCH = window.UNIVSEARCH || {};
-
-  // hide the search bar
-  Cu.import('chrome://the-addon/ToolbarButtonManager.jsm');
-  ToolbarButtonManager.hideToolbarElement(window.document, 'search-container');
-
-  // create the popup element
-  var popup = document.createElementNS("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul", "panel");
-  popup.setAttribute("type", 'autocomplete-richlistbox');
-  popup.setAttribute("id", 'PopupAutoCompleteRichResultUnivSearch');
-  document.getElementById('PopupAutoCompleteRichResult').parentElement.appendChild(popup);
-  var urlbar = document.getElementById('urlbar');
-  UNIVSEARCH.elements = {
-    popup: popup,
-    urlbar: urlbar
-  };
-
-  // dynamically append the stylesheet which binds the autocomplete popup
-  var stylesheet = window.document.createElementNS('http://www.w3.org/1999/xhtml', 'h:link');
-  stylesheet.rel = 'stylesheet';
-  stylesheet.href = 'chrome://the-addon/content/skin/binding.css';
-  stylesheet.type = 'text/css';
-  stylesheet.style.display = 'none';
-  window.document.documentElement.appendChild(stylesheet);
-
-  // TODO dynamically set the src on the iframe, then set up messaging when it loads
-
-  // override some stuff on the urlbar
-  UNIVSEARCH.replaced = {};
-  // TODO: implement this...
-  // UNIVSEARCH.replaced.autocompletesearch = urlbar.getAttribute('autocompletesearch');
-  // urlbar.setAttribute('autocompletesearch', 'univ-search-results');
-  UNIVSEARCH.replaced.autocompletepopup = urlbar.getAttribute('autocompletepopup');
-  urlbar.setAttribute('autocompletepopup', 'PopupAutoCompleteRichResultUnivSearch');
-
-  // add urlbar and gBrowser.tabContainer listeners
-  // obviously we won't put everything top-level on the app namespace, just sketching here
-  popup.addEventListener('popuphiding', UNIVSEARCH.onPopupHiding);
-  popup.addEventListener('popupshowing', UNIVSEARCH.onPopupShowing);
-  gBrowser.tabContainer.addEventListener('TabSelect', UNIVSEARCH.onTabSelect);
-  gBrowser.tabContainer.addEventListener('TabOpen', UNIVSEARCH.onTabOpen);
-  gBrowser.tabContainer.addEventListener('TabClose', UNIVSEARCH.onTabClose);
-  // TODO add urlbar listeners
-
-  // deal with the "go button" (right arrow that appears when you type in the bar)
-  var goButton = document.getElementById('urlbar-go-button');
-  UNIVSEARCH.elements.goButton = goButton;
-  UNIVSEARCH.replaced.goButtonClick = goButton.getAttribute('onclick');
-  // add our handler, fall through to the existing go button behavior
-  goButton.setAttribute('onclick', 'UNIVSEARCH.goButtonClick(); ' + UNIVSEARCH.replaced.goButtonClick);
-
-  // TODO add history dropmarker stanza
+  Main.load();
 }
 
-// shutdown is called:
-// - when extension is uninstalled, if currently enabled
-// - when extension becomes disabled
-// - when FF shuts down, if the extension is enabled
 function shutdown(data, reason) {
-  console.log('shutting down');
+  // no teardown is needed for a normal shutdown
+  if (reason == APP_SHUTDOWN) { return; }
+
+  var winMediator = Cc['@mozilla.org/appshell/window-mediator;1'].getService(Ci.nsIWindowMediator);
+  winMediator.removeListener(mediatorListener);
+}
+
+function install(data, reason) {
+  // upsell? product tour? other first time experience?
+  // TODO: xhr the install event to a server
+}
+
+function uninstall(data, reason) {
+  // uninstall / offboarding experience? ask for feedback?
+  // TODO: xhr the uninstall event to a server
 }

--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,0 +1,3 @@
+content universalsearch chrome/content/
+content universalsearch-root chrome/
+content universalsearch-lib lib/

--- a/chrome/content/content.xml
+++ b/chrome/content/content.xml
@@ -56,6 +56,14 @@
           ]]>
         </body>
       </method>
+      <method name="onKeyPress">
+        <parameter name="aEvent">
+        <body>
+          <![CDATA[
+            US.popup.onKeyPress(aEvent);
+          ]]>
+        </body>
+      </method>
 
     </implementation>
   </binding>

--- a/chrome/content/content.xml
+++ b/chrome/content/content.xml
@@ -57,15 +57,6 @@
         </body>
       </method>
 
-      <method name="onKeyPress">
-        <parameter name="aEvent">
-        <body>
-          <![CDATA[
-            // override inherited method
-          ]]>
-        </body>
-      </method>
-
     </implementation>
   </binding>
 </bindings>

--- a/chrome/content/content.xml
+++ b/chrome/content/content.xml
@@ -4,31 +4,24 @@
           xmlns:html="http://www.w3.org/1999/xhtml"
           xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
           xmlns:xbl="http://www.mozilla.org/xbl">
-  <binding id="autocomplete-rich-result-popup-univ-search" extends="chrome://global/content/bindings/autocomplete.xml#autocomplete-rich-result-popup" >
-    <!-- TODO: could we just load the CSS with moz-binding here, instead of
-         dynamically appending it? -->
+  <binding id="autocomplete-rich-result-popup-univ-search" extends="chrome://global/content/bindings/autocomplete.xml#autocomplete-rich-result-popup">
     <content ignorekeys="false" level="top" consumeoutsideclicks="false">
-      <!-- TODO: 
-           in regular gecko-dev, we had to dynamically set browser.src
-           to avoid the window load event firing before our handler attached.
-           I don't know if that's necessary here, but we'll just see if doing
-           the existing thing works. -->
-      <xul:browser anonid="universal-search-iframe" type="content" height="416" minheight="416" flex="1" />
+      <xul:browser anonid="infect-and-destroy" type="content" height="416" minheight="416" flex="1" />
     </content>
 
-    <implementation implements="nsIAutoCompletePopup">
-      <constructor><![CDATA[
-        // grab a reference to the browser and pass it to JS
-        this.browserEl = document.getAnonymousElementByAttribute(this, "anonid", "universal-search-iframe");
-        UNIVSEARCH.elements.iframe = this.browserEl;
-      ]]></constructor>
-
-      <!-- not sure how much to put in the XBL methods,
-           leaning on cliqz and autocomplete.xml -->
-      <property name="selectedIndex" onget="return 0;">
+    <implementation>
+       <constructor>
+        <![CDATA[
+          this.browser = document.getAnonymousElementByAttribute(this, 'anonid', 'infect-and-destroy');
+          // TODO: do we really need to do this?
+          US.popup.setBrowser(this.browser);
+        ]]>
+      </constructor>
+      <property name="selectedIndex"
+                onget="return 0;">
         <setter>
           <![CDATA[
-            // we don't do anything here, we just need to overwrite the built-in method
+            // override inherited method
           ]]>
         </setter>
       </property>
@@ -39,35 +32,41 @@
           ]]>
         </body>
       </method>
+      <method name="_openAutocompletePopup">
+        <parameter name="aInput"/>
+        <parameter name="aElement"/>
+        <body>
+          <![CDATA[
+          if (!this.mPopupOpen) {
+            this.mInput = aInput;
+            this._invalidate();
+
+            var width = aElement.getBoundingClientRect().width;
+            this.setAttribute("width", width > 500 ? width : 500);
+            this.openPopup(aElement, "after_start", 0, 0, false, true);
+          }
+        ]]>
+        </body>
+      </method>
+
       <method name="_appendCurrentResult">
         <body>
           <![CDATA[
-            // we will set contents via JS in DOM Level 0 style:
-            // MYAPP.popup._appendCurrentResult = some function
+            // override inherited method
           ]]>
         </body>
       </method>
-      <method name="_openAutocompletePopup">
-        <parameter name="aInput">
-        <parameter name="aElement">
+
+      <method name="onKeyPress">
+        <parameter name="aEvent">
         <body>
           <![CDATA[
-            if (!this.mPopupOpen) {
-              this.mInput = aInput;
-              this._invalidate();
-
-              // XXX if we want to go full-width again, we would do that here.
-              //     sticking with the built-in width calculation for now.
-              var width = aElement.getBoundingClientRect().width;
-              this.setAttribute("width", width > 100 ? width : 100);
-
-              this.openPopup(aElement, "after_start", 0, 0, false, true);
-            }
+            // override inherited method
           ]]>
         </body>
       </method>
 
-  
-
-
+    </implementation>
+  </binding>
+</bindings>
 

--- a/chrome/skin/binding.css
+++ b/chrome/skin/binding.css
@@ -1,6 +1,5 @@
 #PopupAutoCompleteRichResultUnivSearch {
-  /* TODO figure out our addon name so this url will resolve */
-  -moz-binding: url("chrome://the-addon/chrome/content.xml#autocomplete-rich-result-popup-univ-search");
-  /* TODO should we set the height here, or is setting it on the browser el enough? */
-  height: 416px;
+  -moz-binding: url("chrome://universalsearch/content/content.xml#autocomplete-rich-result-popup-univ-search");
+  min-height: 303px;
+  overflow: hidden;
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-var self = require('sdk/self');
-
-// a dummy function, to show how tests work.
-// to see how to test this function, look at test/test-index.js
-function dummy(text, callback) {
-  callback(text);
-}
-
-exports.dummy = dummy;

--- a/install.rdf
+++ b/install.rdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+    <Description about="urn:mozilla:install-manifest">
+          <em:id>whatever@mozilla-universal-search-addon</em:id>
+
+          <em:bootstrap>true</em:bootstrap>
+          <em:type>2</em:type>
+
+          <em:unpack>false</em:unpack>
+          <em:version>1.0.0</em:version>
+          <em:name>mozilla-universal-search-addon</em:name>
+          <em:description>universal search desktop experiments in addon format</em:description>
+          <em:creator/>
+          <em:homepageURL>https://github.com/mozilla/universal-search-addon</em:homepageURL>
+
+          <em:targetApplication>
+            <Description>
+              <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+              <em:minVersion>38.0a1</em:minVersion>
+              <em:maxVersion>39.0</em:maxVersion>
+            </Description>
+          </em:targetApplication>
+    </Description>
+</RDF>

--- a/lib/main.js
+++ b/lib/main.js
@@ -50,6 +50,7 @@ var loadIntoWindow = function(win) {
   // grab node pointers and swap the popup into the DOM.
   win.US.urlbar = new win.Urlbar();
   win.US.urlbar.render(win);
+  win.US.gURLBar = win.gURLBar;
 
   // add urlbar and gBrowser.tabContainer listeners
   // obviously we won't put everything top-level on the app namespace, just sketching here

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,103 @@
+// TODO: bootstrapped extensions cache strings, scripts, etc forever.
+//       figure out when and how to cache-bust.
+//       bugs 918033, 1051238, 719376
+
+const { classes: Cc, interfaces: Ci, utils: Cu, manager: Cm } = Components;
+Cu.import('resource://gre/modules/XPCOMUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'Services',
+  'resource://gre/modules/Services.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'WebChannel',
+  'resource://gre/modules/WebChannel.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'console',
+  'resource://gre/modules/devtools/Console.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'ToolbarButtonManager',
+  'chrome://universalsearch-lib/content/third-party/ToolbarButtonManager.js');
+
+var EXPORTED_SYMBOLS = ['Main'];
+
+var loadIntoWindow = function(win) {
+  console.log('loadIntoWindow start');
+
+  var document = win.document;
+
+  // set the app global per-window
+  if(win.US === undefined) {
+      Object.defineProperty(win, 'US', {configurable:true, value:{}});
+  } else {
+      win.US = win.US || {};
+  }
+
+  // hide the search bar
+  ToolbarButtonManager.hideToolbarElement(win.document, 'search-container');
+
+  // use Services.scriptloader.loadSubScript to load any addl scripts.
+  Services.scriptloader.loadSubScript('chrome://universalsearch-lib/content/ui/Popup.js', win);
+  Services.scriptloader.loadSubScript('chrome://universalsearch-lib/content/ui/Urlbar.js', win);
+  Services.scriptloader.loadSubScript('chrome://universalsearch-lib/content/ui/GoButton.js', win);
+
+  // load the CSS into the document. not using the stylesheet service.
+  var stylesheet = document.createElementNS('http://www.w3.org/1999/xhtml', 'h:link');
+  stylesheet.rel = 'stylesheet';
+  stylesheet.href = 'chrome://universalsearch-root/content/skin/binding.css';
+  stylesheet.type = 'text/css';
+  stylesheet.style.display = 'none';
+  document.documentElement.appendChild(stylesheet);
+
+  // create the popup and append it to the dom.
+  win.US.popup = new win.Popup();
+  win.US.popup.render(win);
+
+  // grab node pointers and swap the popup into the DOM.
+  win.US.urlbar = new win.Urlbar();
+  win.US.urlbar.render(win);
+
+  // add urlbar and gBrowser.tabContainer listeners
+  // obviously we won't put everything top-level on the app namespace, just sketching here
+  win.gBrowser.tabContainer.addEventListener('TabSelect', function onTabSelect() {
+    console.log('onTabSelect');
+  });
+  win.gBrowser.tabContainer.addEventListener('TabOpen', function onTabOpen() {
+    console.log('onTabOpen');
+  });
+  win.gBrowser.tabContainer.addEventListener('TabClose', function onTabClose() {
+    console.log('onTabClose');
+  });
+
+  // deal with the "go button" (right arrow that appears when you type in the bar)
+  win.US.goButton = new win.GoButton();
+  win.US.goButton.render(win);
+
+  // we call this function when the XBL loads, so we can get a pointer to the anonymous
+  // browser element.
+  win.US.setBrowser = function(browserEl) {
+    win.US.browser = browserEl;
+  }
+};
+
+// 1. Extension.load: get a window enumerator, and load the code into each window.
+function load() {
+  console.log('load start');
+  var enumerator = Services.wm.getEnumerator('navigator:browser');
+  while (enumerator.hasMoreElements()) {
+    console.log('enumerator has a window');
+    var win = enumerator.getNext();
+    try { 
+      loadIntoWindow(win);
+    } catch (ex) {
+      console.log('load into window failed: ', ex);
+    }
+  }
+  Services.ww.registerNotification(function(win, topic) {
+    if (topic == 'domwindowopened') {
+    console.log('iterating windows');
+      win.addEventListener('load', function loader() {
+        win.removeEventListener('load', loader, false); 
+        if (win.location.href == 'chrome://browser/content/browser.xul') {
+          loadIntoWindow(win);
+        }
+      }, false);
+    }
+  });
+};
+
+var Main = { load: load };

--- a/lib/third-party/ToolbarButtonManager.js
+++ b/lib/third-party/ToolbarButtonManager.js
@@ -118,6 +118,8 @@ function getCurrentset(toolbar) {
           toolbar.getAttribute("defaultset")).split(",");
 }
 
+// TODO: remove / rewrite this bit
+
 // cliqz
 ToolbarButtonManager.hideToolbarElement = function(doc, id){
   function $(sel, all)

--- a/lib/ui/GoButton.js
+++ b/lib/ui/GoButton.js
@@ -1,0 +1,22 @@
+// JS for the "go button" (right arrow that appears when you type in the urlbar)
+
+'use strict';
+
+var EXPORTED_SYMBOLS = [ 'GoButton' ];
+
+function GoButton() {}
+GoButton.prototype = {
+  // replaced handlers and elements
+  replaced: {},
+  render: function(win) {
+    this.button = document.getElementById('urlbar-go-button');
+    this.replaced.goButtonClick = this.button.getAttribute('onclick');
+    // add our handler, fall through to the existing go button behavior
+    this.button.setAttribute('onclick', 'US.goButton.onClick(); ' + this.replaced.goButtonClick);
+  },
+  onClick: function(evt) {
+    console.log('goButton clicked');
+    return false; // let's not fall through for now
+  }
+};
+

--- a/lib/ui/Popup.js
+++ b/lib/ui/Popup.js
@@ -22,7 +22,6 @@ function Popup() {
 };
 Popup.prototype = {
   constructor: Popup,
-  replaced: {},
   init: function() {},
   port: null,
   render:  function(win) {
@@ -36,10 +35,6 @@ Popup.prototype = {
 
     // wait till the XBL binding is applied, then override these methods
     this.popup._appendCurrentResult = this._appendCurrentResult.bind(this);
-
-    // hang on to the original method & fall through
-    this.replaced.onKeyPress = this.popup.onKeyPress;
-    this.popup.onKeyPress = this.onKeyPress.bind(this);
 
     this.popup.addEventListener('popuphiding', this.onPopupHiding.bind(this));
     this.popup.addEventListener('popupshowing', this.onPopupShowing.bind(this));
@@ -115,67 +110,6 @@ Popup.prototype = {
       browser: this.browser,
       principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
     });
-  },
-  // TODO: this is the original logic from the gecko prototype. maybe we want
-  //       to rethink a bit.
-  onKeyPress: function(evt) {
-    console.log('key press');
-    var gURLBar = window.US.gURLBar;
-    var gBrowser = window.gBrowser;
-
-    if (!this.port) {
-      // keypress happened before iframe was ready, so ignore it
-      // TODO: queue up key events?
-    } else if (evt.ctrlKey || evt.altKey || evt.metaKey) {
-      // special keys could mean a hotkey combination, so bail
-      this.port.send({ type: 'popupclose' }, {
-        browser: this.browser,
-        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
-      });
-      this.popup.closePopup();
-    } else if (['ArrowLeft', 'ArrowRight', 'Escape', 'Enter', 'Backspace'].indexOf(evt.key) > -1) {
-      // if there was only one char in the urlbar, then the backspace will empty it out, so we should
-      // hide the popup. but if there's more than one char in there, we'll probably get some results
-      // from autocomplete searching on the substring in just a moment, so do nothing.
-      // TODO: when we reimplement the controller, actually check the location of the cursor...the backspace
-      // could do nothing if it was in front of the character. And we shoudl probably check for cursor location
-      // and listen for the Del key too. And the trim() call could also mess things up. Selections are a real PITA ;-)
-      if (evt.key == 'Backspace' && gURLBar.inputField.value.trim().length > 1) { return; }
-
-      // ok, if the user selected something, we set state on gURLBar.
-      if (evt.key == 'Enter') {
-        if (gURLBar.search && gURLBar.search.term == gURLBar.value) {
-          // the user selected a search suggestion via keypresses, then hit enter.
-          // we know the suggestion is not stale, because it matches the current contents
-          // of the urlbar. So, navigate to the hidden search URL that corresponds to the term.
-          gBrowser.loadURI(gURLBar.search.url);
-          gURLBar.search = null;
-        } else {
-          // hmm, when we key over non-search values, hitting enter doesn't quite work.
-          // maybe just surf to whatever's in the urlbar?
-          gBrowser.loadURI(gURLBar.value);
-        }
-      }
-
-      // we need to close the popup; tell the iframe
-      gBrowser.yay.chan.send({
-        type: 'popupclose'
-      }, gBrowser.yay.brow);
-      this.popup.closePopup();
-    } else if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Tab'].indexOf(evt.key) > -1) {
-      // TODO: either duplicate or simply reuse the remaining key handling behavior below, like the bit
-      // where we ignore keys that are part of a keyboard shortcut
-      gBrowser.yay.chan.send({
-        type: 'navigational-key',
-        data: {
-          key: evt.key,
-          shiftKey: evt.shiftKey
-        }
-      }, gBrowser.yay.brow);
-    }
-
-    // now back to the other handler
-    this.replaced.onKeyPress.call(this.popup, evt);
   },
   _getImageURLForResolution: function(aWin, aURL, aWidth, aHeight) {
     if (!aURL.endsWith('.ico') && !aURL.endsWith('.ICO')) {

--- a/lib/ui/Popup.js
+++ b/lib/ui/Popup.js
@@ -1,0 +1,217 @@
+// popup event handlers on the chrome side
+
+'use strict';
+
+XPCOMUtils.defineLazyModuleGetter(this, 'SearchSuggestionController',
+  'resource://gre/modules/SearchSuggestionController.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'Promise',
+  'resource://gre/modules/Promise.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'WebChannel',
+  'resource://gre/modules/WebChannel.jsm');
+
+var EXPORTED_SYMBOLS = [ 'Popup' ];
+
+function Popup() {
+  var prefBranch = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).getBranch("");
+  this.channelID = 'ohai';
+  this.frameURL = prefBranch.getPrefType('services.universalSearch.frameURL') ?
+                   prefBranch.getCharPref('services.universalSearch.frameURL') :
+                   'https://localhost/github/mozilla-universal-search-content/index.html';
+  this.frameBaseURL = prefBranch.getPrefType('services.universalSearch.baseURL') ?
+                       prefBranch.getCharPref('services.universalSearch.baseURL') : 'https://localhost';
+};
+Popup.prototype = {
+  constructor: Popup,
+  init: function() {},
+  port: null,
+  render:  function(win) {
+    this.popup = win.document.createElementNS('http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul', 'panel');
+    this.popup.setAttribute('type', 'autocomplete-richlistbox');
+    this.popup.setAttribute('id', 'PopupAutoCompleteRichResultUnivSearch');
+    this.popup.setAttribute('noautofocus', 'true');
+
+    this.popupParent = win.document.getElementById('PopupAutoCompleteRichResult').parentElement;
+    this.popupParent.appendChild(this.popup);
+
+    // wait till the XBL binding is applied, then override these methods
+    this.popup._appendCurrentResult = this._appendCurrentResult.bind(this);
+    this.popup.onKeyPress = this.onKeyPress.bind(this);
+
+    this.popup.addEventListener('popuphiding', this.onPopupHiding.bind(this));
+    this.popup.addEventListener('popupshowing', this.onPopupShowing.bind(this));
+
+    // XXX: We aren't really initialized yet. We wait to set up the WebChannel
+    //      until the browser element loads. It's an anonymous XUL node, so we
+    //      wait until our XBL constructor is called, and it passes us the node.
+  },
+  // Set the iframe src and wire up ready listener that will attach the WebChannel.
+  // Invoked by the XBL constructor, which passes in the anonymous browser element.
+  //
+  // TODO: I don't understand the logic behind when XBL constructors fire, so this
+  // might run repeatedly on the same window, causing WebChannels, etc, to be leaked.
+  setBrowser: function(browserEl) {
+    if (this.rendered) { return; }
+    this.browser = browserEl;
+    this.browser.addEventListener('load', this.onBrowserLoaded.bind(this), true);
+    this.browser.setAttribute('src', this.frameURL + '?cachebust=' + Date.now());
+  },
+  // when the iframe is ready, load up the WebChannel
+  onBrowserLoaded: function() {
+    this.browser.removeEventListener('load', this.onBrowserLoaded.bind(this), true);
+    this.browser.messageManager.loadFrameScript('chrome://browser/content/content.js', true);
+
+    this.port = new WebChannel(this.channelID, Services.io.newURI(this.frameBaseURL, null, null));
+    this.port.listen(this.onMessage.bind(this));
+  },
+  onMessage: function(id, msg, sender) {
+    var engine = Services.search.defaultEngine;
+    var url;
+    if (id != this.channelID) { return; }
+    if (msg.type == 'autocomplete-url-clicked') {
+      console.log('autocomplete widget received "autocomplete-url-clicked" event');
+      this.popup.hidePopup();
+      if (msg.data.resultType == 'url') {
+        // it's navigable, go for it
+        window.US.urlbar.inputField.value = msg.data.result;
+        window.gBrowser.loadURI(msg.data.result);
+      } else {
+        // it's a search suggestion, so:
+        // grab the search service, get the URL, navigate to _that_
+        url = engine.getSubmission(msg.data.result).uri.spec;
+        window.US.urlbar.inputField.value = url;
+        window.gBrowser.loadURI(url);
+      }
+    } else if (msg.type == 'url-selected') {
+      console.log('autocomplete widget received "url-selected" event');
+      if (msg.data.resultType == 'url') {
+        window.US.urlbar.value = msg.data.result;
+        window.US.urlbar._search = null;
+      } else {
+        // show the search term in the address bar,
+        // but if the user hits 'enter', navigate to the search result page.
+        // we may not always null out _search in time, so we will check if
+        // the search term in the gURLBar.value matches gURLBar._search.term
+        // before we navigate to the gURLBar._search.url.
+        window.US.urlbar.value = msg.data.result;
+        url = engine.getSubmission(msg.data.result).uri.spec;
+        window.US.urlbar._search = { term: msg.data.result, url: url };
+      }
+    }
+  },
+  onPopupShowing: function() {
+    if (!this.port) { return; }
+    this.port.send({ type: 'popupopen' }, {
+      browser: this.browser,
+      principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+    });
+  },
+  onPopupHiding: function() {
+    if (!this.port) { return; }
+    this.port.send({ type: 'popupclose' }, {
+      browser: this.browser,
+      principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+    });
+  },
+  onKeyPress: function() {
+    console.log('key press');
+  },
+  _getImageURLForResolution: function(aWin, aURL, aWidth, aHeight) {
+    if (!aURL.endsWith('.ico') && !aURL.endsWith('.ICO')) {
+      return aURL;
+    }
+    let width  = Math.round(aWidth * aWin.devicePixelRatio);
+    let height = Math.round(aHeight * aWin.devicePixelRatio);
+    return aURL + (aURL.contains("#") ? "&" : "#") +
+           "-moz-resolution=" + width + "," + height;
+
+  },
+  _appendCurrentResult: function() {
+    var autocompleteResults = this._getAutocompleteSearchResults();
+    var searchSuggestions = this._getSearchSuggestions();
+    console.log('autocompleteResults is ',autocompleteResults);
+    console.log('searchSuggestions is ',searchSuggestions);
+    this.port.send({ type: 'autocomplete-search-results', data: autocompleteResults }, {
+      browser: this.browser,
+      principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+    });
+    this.port.send({ type: 'suggested-search-results', data: searchSuggestions}, {
+      browser: this.browser,
+      principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+    });
+  },
+  _getAutocompleteSearchResults: function() {
+    var controller = this.popup.mInput.controller;
+    var maxResults = 5;
+    var results = [];
+
+    // the controller's searchStatus is not a reliable way to decide when/what to send.
+    // instead, we'll just check the number of results and act accordingly.
+    if (controller.matchCount) {
+      results = [];
+      for (var i = 0; i < Math.min(maxResults, controller.matchCount); i++) {
+        var chromeImgLink = this._getImageURLForResolution(window, controller.getImageAt(i), 16, 16);
+        // if we have a favicon link, it'll be of the form "moz-anno:favicon:http://link/to/favicon"
+        // else, it'll be a chrome:// link to the default favicon img
+        var imgMatches = chromeImgLink.match(/^moz-anno\:favicon\:(.*)/);
+
+        results.push({
+          url: Components.classes["@mozilla.org/intl/texttosuburi;1"].
+                getService(Components.interfaces.nsITextToSubURI).
+                unEscapeURIForUI("UTF-8", controller.getValueAt(i)),
+          image: imgMatches ? imgMatches[1] : null,
+          title: controller.getCommentAt(i),
+          type: controller.getStyleAt(i),
+          text: controller.searchString.replace(/^\s+/, "").replace(/\s+$/, "")
+        });
+      }
+    }
+    return results;
+  },
+  _getSearchSuggestions: function() {
+    //
+    // now, we also want to include the search suggestions in the output, via some separate signal.
+    // a lot of this code lifted from browser/modules/AboutHome.jsm and browser/modules/ContentSearch.jsm
+    // ( face-with-open-mouth-and-cold-sweat-emoji ), heh
+    //
+    // TODO: maybe just send signals to ContentSearch instead, the problem there is that I couldn't
+    // figure out which message manager to pass into ContentSearch, in order to get the response message back.
+    // it's possible all of this code was unnecessary and we could just fire a GetSuggestions message into
+    // the ether, and fully expect to get a Suggestions object back with the suggestions. /me shrugs
+    // 
+    //var suggestionData = { engineName: engine.name, searchString: gURLBar.inputField.value, remoteTimeout: 5000 };
+    //ContentSearch._onMessageGetSuggestions(brow.messageManager, suggestionData);
+    var controller = this.popup.mInput.controller;
+
+    // it seems like Services.search.isInitialized is always true?
+    if (!Services.search.isInitialized) {
+      return;
+    }
+    let MAX_LOCAL_SUGGESTIONS = 3;
+    let MAX_SUGGESTIONS = 6;
+    let REMOTE_TIMEOUT = 500; // same timeout as in SearchSuggestionController.jsm
+    let isPrivateBrowsingSession = false; // we don't care about this right now
+
+    // searchTerm is the same thing as the 'text' item sent down in each result.
+    // maybe that's not a useful place to put the search term...
+    let searchTerm = controller.searchString.replace(/^\s+/, "").replace(/\s+$/, "")
+
+    // unfortunately, the controller wants to do some UI twiddling.
+    // and we don't have any UI to give it. so it barfs.
+    let searchController = new SearchSuggestionController();
+    let engine = Services.search.currentEngine;
+    let ok = SearchSuggestionController.engineOffersSuggestions(engine);
+
+    searchController.maxLocalResults = ok ? MAX_LOCAL_SUGGESTIONS : MAX_SUGGESTIONS;
+    searchController.maxRemoteResults = ok ? MAX_SUGGESTIONS : 0;
+    searchController.remoteTimeout = REMOTE_TIMEOUT;
+
+    let suggestions = searchController.fetch(searchTerm, isPrivateBrowsingSession, engine);
+    // returns a promise for the formatted results of the search suggestion engine
+    return suggestions.then(function(dataz) {
+      delete dataz.formHistoryResult;
+      return dataz;
+    });
+  },
+  onPopupHiding: function() { console.log('onPopupHiding') },
+  onPopupShowing: function() { console.log('onPopupShowing') },
+};

--- a/lib/ui/Popup.js
+++ b/lib/ui/Popup.js
@@ -76,29 +76,29 @@ Popup.prototype = {
       this.popup.hidePopup();
       if (msg.data.resultType == 'url') {
         // it's navigable, go for it
-        window.US.urlbar.inputField.value = msg.data.result;
+        window.US.gURLBar.inputField.value = msg.data.result;
         window.gBrowser.loadURI(msg.data.result);
       } else {
         // it's a search suggestion, so:
         // grab the search service, get the URL, navigate to _that_
         url = engine.getSubmission(msg.data.result).uri.spec;
-        window.US.urlbar.inputField.value = url;
+        window.US.gURLBar.inputField.value = url;
         window.gBrowser.loadURI(url);
       }
     } else if (msg.type == 'url-selected') {
       console.log('autocomplete widget received "url-selected" event');
       if (msg.data.resultType == 'url') {
-        window.US.urlbar.value = msg.data.result;
-        window.US.urlbar._search = null;
+        window.US.gURLBar.value = msg.data.result;
+        window.US.gURLBar._search = null;
       } else {
         // show the search term in the address bar,
         // but if the user hits 'enter', navigate to the search result page.
         // we may not always null out _search in time, so we will check if
         // the search term in the gURLBar.value matches gURLBar._search.term
         // before we navigate to the gURLBar._search.url.
-        window.US.urlbar.value = msg.data.result;
+        window.US.gURLBar.value = msg.data.result;
         url = engine.getSubmission(msg.data.result).uri.spec;
-        window.US.urlbar._search = { term: msg.data.result, url: url };
+        window.US.gURLBar._search = { term: msg.data.result, url: url };
       }
     }
   },
@@ -120,7 +120,7 @@ Popup.prototype = {
   //       to rethink a bit.
   onKeyPress: function(evt) {
     console.log('key press');
-    var gURLBar = window.US.urlbar;
+    var gURLBar = window.US.gURLBar;
     var gBrowser = window.gBrowser;
 
     if (!this.port) {

--- a/lib/ui/Popup.js
+++ b/lib/ui/Popup.js
@@ -22,6 +22,7 @@ function Popup() {
 };
 Popup.prototype = {
   constructor: Popup,
+  replaced: {},
   init: function() {},
   port: null,
   render:  function(win) {
@@ -35,6 +36,9 @@ Popup.prototype = {
 
     // wait till the XBL binding is applied, then override these methods
     this.popup._appendCurrentResult = this._appendCurrentResult.bind(this);
+
+    // hang on to the original method & fall through
+    this.replaced.onKeyPress = this.popup.onKeyPress;
     this.popup.onKeyPress = this.onKeyPress.bind(this);
 
     this.popup.addEventListener('popuphiding', this.onPopupHiding.bind(this));
@@ -112,8 +116,66 @@ Popup.prototype = {
       principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
     });
   },
-  onKeyPress: function() {
+  // TODO: this is the original logic from the gecko prototype. maybe we want
+  //       to rethink a bit.
+  onKeyPress: function(evt) {
     console.log('key press');
+    var gURLBar = window.US.urlbar;
+    var gBrowser = window.gBrowser;
+
+    if (!this.port) {
+      // keypress happened before iframe was ready, so ignore it
+      // TODO: queue up key events?
+    } else if (evt.ctrlKey || evt.altKey || evt.metaKey) {
+      // special keys could mean a hotkey combination, so bail
+      this.port.send({ type: 'popupclose' }, {
+        browser: this.browser,
+        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+      });
+      this.popup.closePopup();
+    } else if (['ArrowLeft', 'ArrowRight', 'Escape', 'Enter', 'Backspace'].indexOf(evt.key) > -1) {
+      // if there was only one char in the urlbar, then the backspace will empty it out, so we should
+      // hide the popup. but if there's more than one char in there, we'll probably get some results
+      // from autocomplete searching on the substring in just a moment, so do nothing.
+      // TODO: when we reimplement the controller, actually check the location of the cursor...the backspace
+      // could do nothing if it was in front of the character. And we shoudl probably check for cursor location
+      // and listen for the Del key too. And the trim() call could also mess things up. Selections are a real PITA ;-)
+      if (evt.key == 'Backspace' && gURLBar.inputField.value.trim().length > 1) { return; }
+
+      // ok, if the user selected something, we set state on gURLBar.
+      if (evt.key == 'Enter') {
+        if (gURLBar.search && gURLBar.search.term == gURLBar.value) {
+          // the user selected a search suggestion via keypresses, then hit enter.
+          // we know the suggestion is not stale, because it matches the current contents
+          // of the urlbar. So, navigate to the hidden search URL that corresponds to the term.
+          gBrowser.loadURI(gURLBar.search.url);
+          gURLBar.search = null;
+        } else {
+          // hmm, when we key over non-search values, hitting enter doesn't quite work.
+          // maybe just surf to whatever's in the urlbar?
+          gBrowser.loadURI(gURLBar.value);
+        }
+      }
+
+      // we need to close the popup; tell the iframe
+      gBrowser.yay.chan.send({
+        type: 'popupclose'
+      }, gBrowser.yay.brow);
+      this.popup.closePopup();
+    } else if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Tab'].indexOf(evt.key) > -1) {
+      // TODO: either duplicate or simply reuse the remaining key handling behavior below, like the bit
+      // where we ignore keys that are part of a keyboard shortcut
+      gBrowser.yay.chan.send({
+        type: 'navigational-key',
+        data: {
+          key: evt.key,
+          shiftKey: evt.shiftKey
+        }
+      }, gBrowser.yay.brow);
+    }
+
+    // now back to the other handler
+    this.replaced.onKeyPress.call(this.popup, evt);
   },
   _getImageURLForResolution: function(aWin, aURL, aWidth, aHeight) {
     if (!aURL.endsWith('.ico') && !aURL.endsWith('.ICO')) {

--- a/lib/ui/Urlbar.js
+++ b/lib/ui/Urlbar.js
@@ -28,8 +28,72 @@ Urlbar.prototype = {
   },
   onFocus: function(evt) {},
   onBlur: function(evt) {},
-  onKeyDown: function(evt) {},
-  onKeyPress: function(evt) {},
+
+  // TODO: this is the original logic from the gecko prototype. maybe we want
+  //       to rethink a bit.
+  onKeyDown: function(evt) {
+    console.log('Urlbar.onKeyDown');
+    var gURLBar = this.urlbar;
+    var gBrowser = window.gBrowser;
+
+    if (evt.ctrlKey || evt.altKey || evt.metaKey) {
+      // special keys could mean a hotkey combination, so bail
+      // TODO: extract port from popup so that urlbar can use it too
+      US.popup.port.send({ type: 'popupclose' }, {
+        browser: US.popup.browser,
+        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+      });
+      US.popup.popup.closePopup();
+    } else if (['ArrowLeft', 'ArrowRight', 'Escape', 'Enter', 'Backspace'].indexOf(evt.key) > -1) {
+      // if there was only one char in the urlbar, then the backspace will empty it out, so we should
+      // hide the popup. but if there's more than one char in there, we'll probably get some results
+      // from autocomplete searching on the substring in just a moment, so do nothing.
+      // TODO: when we reimplement the controller, actually check the location of the cursor...the backspace
+      // could do nothing if it was in front of the character. And we shoudl probably check for cursor location
+      // and listen for the Del key too. And the trim() call could also mess things up. Selections are a real PITA ;-)
+      if (evt.key == 'Backspace' && gURLBar.inputField.value.trim().length > 1) { return; }
+
+      // ok, if the user selected something, we set state on gURLBar.
+      if (evt.key == 'Enter') {
+        if (gURLBar.search && gURLBar.search.term == gURLBar.value) {
+          // the user selected a search suggestion via keypresses, then hit enter.
+          // we know the suggestion is not stale, because it matches the current contents
+          // of the urlbar. So, navigate to the hidden search URL that corresponds to the term.
+          gBrowser.loadURI(gURLBar.search.url);
+          gURLBar.search = null;
+        } else {
+          // hmm, when we key over non-search values, hitting enter doesn't quite work.
+          // maybe just surf to whatever's in the urlbar?
+          gBrowser.loadURI(gURLBar.value);
+        }
+      }
+
+      // we need to close the popup; tell the iframe
+      US.popup.port.send({ type: 'popupclose' }, {
+        browser: US.popup.browser,
+        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+      });
+      US.popup.popup.closePopup();
+    } else if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Tab'].indexOf(evt.key) > -1) {
+      // TODO: either duplicate or simply reuse the remaining key handling behavior below, like the bit
+      // where we ignore keys that are part of a keyboard shortcut
+      US.popup.port.send({
+        type: 'navigational-key',
+        data: {
+          key: evt.key,
+          shiftKey: evt.shiftKey
+        }
+      }, {
+        browser: US.popup.browser,
+        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+      });
+    }
+
+    // TODO: pull in the other handler behavior
+  },
+  onKeyPress: function(evt) {
+    console.log('Urlbar.onKeyPress');
+  },
   onMouseDown: function(evt) {},
   onPaste: function(evt) {},
   onDrop: function(evt) {}

--- a/lib/ui/Urlbar.js
+++ b/lib/ui/Urlbar.js
@@ -1,0 +1,36 @@
+// urlbar listeners and event handlers
+
+'use strict';
+
+var EXPORTED_SYMBOLS = ['Urlbar'];
+
+function Urlbar() {}
+Urlbar.prototype = {
+  // replaced handlers and elements
+  replaced: {},
+  init: function() {},
+  render: function(win) {
+    this.urlbar = win.document.getElementById('urlbar');
+    this.replaced._autocompletepopup = this.urlbar.getAttribute('autocompletepopup');
+    this.urlbar.setAttribute('autocompletepopup', 'PopupAutoCompleteRichResultUnivSearch');
+
+    this.urlbar.addEventListener('focus', this.onFocus.bind(this));
+    this.urlbar.addEventListener('blur', this.onBlur.bind(this));
+    this.urlbar.addEventListener('keydown', this.onKeyDown.bind(this));
+    this.urlbar.addEventListener('keypress', this.onKeyPress.bind(this));
+    this.urlbar.addEventListener('mousedown', this.onMouseDown.bind(this));
+    this.urlbar.addEventListener('paste', this.onPaste.bind(this));
+    this.urlbar.addEventListener('drop', this.onDrop.bind(this));
+  },
+  derender: function() {
+    // do something with this.replaced, the replaced els
+    // unhook all the listeners
+  },
+  onFocus: function(evt) {},
+  onBlur: function(evt) {},
+  onKeyDown: function(evt) {},
+  onKeyPress: function(evt) {},
+  onMouseDown: function(evt) {},
+  onPaste: function(evt) {},
+  onDrop: function(evt) {}
+};


### PR DESCRIPTION
Handle clicks in the iframe and nav key  (up/dn, tab/shift-tab) events.

Specifically, restore support for the `navigational-key` and `autocomplete-url-clicked` events from the [old API](https://gist.github.com/6a68/48bf56e5b66e8631b522).
