### PR TITLE
Adding stub ESLint task

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,25 @@
+env:
+  browser: true
+  es6: true
+  node: true
+
+globals:
+  Cc: false
+  Ci: false
+  Cm: false
+  Components: false
+  CustomizableUI: false
+  Main: false
+  Services: false
+  SearchSuggestionController: false
+  US: false
+  WebChannel: false
+  XPCOMUtils: false
+
+rules:
+  global-strict: 0
+  no-underscore-dangle: 0
+  no-unused-vars: [2, {vars: all, args: none}]
+  quotes: [0, single]
+  strict: 0
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+*.log
+

--- a/package.json
+++ b/package.json
@@ -1,26 +1,30 @@
 {
   "name": "mozilla-universal-search-addon",
-  "version": "1.0.0",
   "description": "universal search desktop experiments in addon format",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mozilla/universal-search-addon"
-  },
-  "author": "",
-  "license": "MPL2",
+  "version": "1.0.0",
+  "author": "Mozilla (https://mozilla.org/)",
   "bugs": {
     "url": "https://github.com/mozilla/universal-search-addon/issues"
   },
-  "homepage": "https://github.com/mozilla/universal-search-addon",
   "dependencies": {
     "jpm": "^1.0.0"
+  },
+  "devDependencies": {
+    "eslint": "0.23.0"
   },
   "engines": {
     "firefox": ">=38.0a1",
     "fennec": ">=38.0a1"
+  },
+  "homepage": "https://github.com/mozilla/universal-search-addon",
+  "license": "MPL-2.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/universal-search-addon"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }


### PR DESCRIPTION
Alpha quality contribution here... I didn't add a Grunt or Gulp build system, and the ESLint rules still need a bit of tweaking, and the `npm run lint` task doesn't pass yet, but we have to start somewhere (even if that somewhere is closing this PR and telling me to go away).
### Current ESLint output:

``` sh
% npm run lint

> mozilla-universal-search-addon@1.0.0 lint /Users/pdehaan/dev/github/universal-search-addon
> eslint .


bootstrap.js
   3:57  error  Cm is defined but never used         no-unused-vars
   9:9   error  startup is defined but never used    no-unused-vars
  13:9   error  shutdown is defined but never used   no-unused-vars
  15:13  error  Expected '===' and instead saw '=='  eqeqeq
  15:16  error  "APP_SHUTDOWN" is not defined        no-undef
  18:29  error  "mediatorListener" is not defined    no-undef
  21:9   error  install is defined but never used    no-unused-vars
  26:9   error  uninstall is defined but never used  no-unused-vars

lib/main.js
    5:17  error  Cc is defined but never used                       no-unused-vars
    5:33  error  Ci is defined but never used                       no-unused-vars
    5:57  error  Cm is defined but never used                       no-unused-vars
   16:4   error  EXPORTED_SYMBOLS is defined but never used         no-unused-vars
   25:53  error  Missing space before value for key "configurable"  key-spacing
   25:65  error  Missing space before value for key "value"         key-spacing
   75:3   error  Missing semicolon                                  semi
   85:10  error  Trailing spaces not allowed                        no-trailing-spaces
   91:44  error  win is already declared in the upper scope         no-shadow
   92:14  error  Expected '===' and instead saw '=='                eqeqeq
   95:56  error  Trailing spaces not allowed                        no-trailing-spaces
   96:30  error  Expected '===' and instead saw '=='                eqeqeq
  102:1   error  Unnecessary semicolon                              no-extra-semi
  104:4   error  Main is defined but never used                     no-unused-vars

lib/ui/GoButton.js
  5:4  error  EXPORTED_SYMBOLS is defined but never used  no-unused-vars

lib/ui/Popup.js
   12:4   error  EXPORTED_SYMBOLS is defined but never used  no-unused-vars
   22:1   error  Unnecessary semicolon                       no-extra-semi
   23:18  error  Duplicate key 'onPopupShowing'              no-dupe-keys
   23:18  error  Duplicate key 'onPopupHiding'               no-dupe-keys
   26:11  error  Extra space before value for key "render"   key-spacing
   67:11  error  Expected '!==' and instead saw '!='         eqeqeq
   68:17  error  Expected '===' and instead saw '=='         eqeqeq
   71:30  error  Expected '===' and instead saw '=='         eqeqeq
   82:24  error  Expected '===' and instead saw '=='         eqeqeq
   84:30  error  Expected '===' and instead saw '=='         eqeqeq
  117:15  error  Multiple spaces found before '='            no-multi-spaces
  126:41  error  A space is required after ','               comma-spacing
  127:39  error  A space is required after ','               comma-spacing
  175:7   error  Trailing spaces not allowed                 no-trailing-spaces
  191:84  error  Missing semicolon                           semi
  205:4   error  Expected no return value                    consistent-return
  210:58  error  Missing semicolon                           semi
  211:60  error  Missing semicolon                           semi
  211:62  error  Unexpected trailing comma                   comma-dangle

lib/ui/Urlbar.js
   5:4   error  EXPORTED_SYMBOLS is defined but never used  no-unused-vars
  53:18  error  Expected '===' and instead saw '=='         eqeqeq
  56:18  error  Expected '===' and instead saw '=='         eqeqeq
  57:50  error  Expected '===' and instead saw '=='         eqeqeq

✖ 46 problems (46 errors, 0 warnings)
```

I can probably fix most of those style issues in a separate PR if you want. And we can disable any default ESLint rules that you don't like (ie: `comma-dangle`, `consistent-return`, and whatever else, although most make sense and are easy fixes). We can also ignore any errors per-line in ESLint if we want to ignore that `"EXPORTED_SYMBOLS is defined but never used"` message but not bulk disable that `no-unused-vars` rule.
