### PR TITLE
Final tweaks to get to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ Installation / how to hack on this?
 - set up https on your local machine
   - here's a gist with how I got this working (yosemite / built-in apache): https://gist.github.com/6a68/40b5eda14c82a25e253b
 - add a proxy file to the FF profile you will use for addon development
+  - The proxy file connects a copy of FF to a local directory that holds addon source code.
   - See MDN for more: https://developer.mozilla.org/en-US/Add-ons/Setting_up_extension_development_environment#Firefox_extension_proxy_file
 - major TODO: the iframe path needs to be specified using prefs, but using https makes this a bit of a headache.
-  - I'm (Jared) currently using a local file with all the scripts/styles inlined, to avoid setting up a virtualhost.
-    That's the hardcoded localhost path inside lib/ui/Popup.
+  - by default, the iframe points at our cloudfront server, which does use https.
+
+Release process:
+  1. Manually bump the version number in `install.rdf` and `update.rdf`.
+  1. Bump the version number in package.json using `npm version patch`. This will generate a git tag, too.
+  1. Zip up a new addon: `rm -rf dist && mkdir dist && zip dist/addon.xpi *`
+  1. Release the addon to people: `scp dist/addon.xpi jhirsch@people.mozilla.org:public_html/universal-search-addon/addon.xpi`
+  1. Release the update.rdf file to people: `scp update.rdf jhirsch@people.mozilla.org:public_html/universal-search-addon/update.rdf`
+  1. Probably email the universal-search list?

--- a/install.rdf
+++ b/install.rdf
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
-    <Description about="urn:mozilla:install-manifest">
-          <em:id>whatever@mozilla-universal-search-addon</em:id>
+  <Description about="urn:mozilla:install-manifest">
+    <em:id>universal-search-addon@mozilla.com</em:id>
 
-          <em:bootstrap>true</em:bootstrap>
-          <em:type>2</em:type>
+    <em:bootstrap>true</em:bootstrap>
+    <em:type>2</em:type>
 
-          <em:unpack>false</em:unpack>
-          <em:version>1.0.0</em:version>
-          <em:name>mozilla-universal-search-addon</em:name>
-          <em:description>universal search desktop experiments in addon format</em:description>
-          <em:creator/>
-          <em:homepageURL>https://github.com/mozilla/universal-search-addon</em:homepageURL>
+    <em:unpack>false</em:unpack>
+    <em:version>1.0.0</em:version>
+    <em:name>Universal Search Addon</em:name>
+    <em:description>Universal Search desktop FF experiments in addon format</em:description>
+    <em:creator/>
+    <em:homepageURL>https://github.com/mozilla/universal-search-addon</em:homepageURL>
+    <em:updateURL>https://people.mozilla.org/~jhirsch/universal-search-addon/update.rdf</em:updateURL>
 
-          <em:targetApplication>
-            <Description>
-              <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-              <em:minVersion>38.0a1</em:minVersion>
-              <em:maxVersion>39.0</em:maxVersion>
-            </Description>
-          </em:targetApplication>
-    </Description>
+    <em:targetApplication>
+      <Description>
+        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+        <em:minVersion>38.0</em:minVersion>
+        <em:maxVersion>42.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+  </Description>
 </RDF>

--- a/lib/ui/Popup.js
+++ b/lib/ui/Popup.js
@@ -16,9 +16,10 @@ function Popup() {
   this.channelID = 'ohai';
   this.frameURL = prefBranch.getPrefType('services.universalSearch.frameURL') ?
                    prefBranch.getCharPref('services.universalSearch.frameURL') :
-                   'https://localhost/github/mozilla-universal-search-content/index.html';
+                   'https://d1fnkpeapwua2i.cloudfront.net/index.html';
   this.frameBaseURL = prefBranch.getPrefType('services.universalSearch.baseURL') ?
-                       prefBranch.getCharPref('services.universalSearch.baseURL') : 'https://localhost';
+                       prefBranch.getCharPref('services.universalSearch.baseURL') :
+                       'https://d1fnkpeapwua2i.cloudfront.net';
 };
 Popup.prototype = {
   constructor: Popup,

--- a/update.rdf
+++ b/update.rdf
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RDF:RDF xmlns:RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+  <!-- TODO: use a templating library to auto-generate this file from various config values,
+             rather than hard-coding stuff here and in the addon -->
+  <RDF:Description about="urn:mozilla:extension:universal-search-addon@mozilla.com">
+    <em:updates>
+      <RDF:Seq>
+
+        <!-- docs suggest one li per version of the addon...what if we just update all to latest? -->
+        <RDF:li>
+          <RDF:Description>
+            <em:version>1.0.0</em:version>
+            <em:targetApplication>
+              <RDF:Description>
+                <!-- desktop FF UUID -->
+                <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+                <em:minVersion>38.0</em:minVersion>
+                <em:maxVersion>42.*</em:maxVersion>
+                <em:updateLink>https://people.mozilla.org/~jhirsch/universal-search-addon/addon.xpi</em:updateLink>
+              </RDF:Description>
+            </em:targetApplication>
+          </RDF:Description>
+        </RDF:li>
+
+      </RDF:Seq>
+    </em:updates>
+  </RDF:Description>
+</RDF:RDF>


### PR DESCRIPTION
- use the existing cloudfront endpoint for the new iframe
- make the addon self-updating via install.rdf changes and the update.rdf file
- specify manual process for build and release inside README.md

I've verified that the auto-update process works. We'll be hiding the addon behind persona LDAP on https://people.mozilla.org/~jhirsch/universal-search-addon for the extreme short-term.
