### PR TITLE
Cleanup of minor install/uninstall bugs

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -14,9 +14,15 @@ function shutdown(data, reason) {
   // no teardown is needed for a normal shutdown
   if (reason == APP_SHUTDOWN) { return; }
 
-  // TODO: should we instead run Main.unload on abnormal shutdown?
-  var winMediator = Cc['@mozilla.org/appshell/window-mediator;1'].getService(Ci.nsIWindowMediator);
-  winMediator.removeListener(mediatorListener);
+  if (reason == ADDON_DISABLE || reason == ADDON_UNINSTALL) {
+    // uninstall / offboarding experience? ask for feedback?
+    // TODO: xhr the uninstall event to a server
+  }
+
+  // the reason is either disable, uninstall, or shutdown is firing
+  // because we're in the middle of a downgrade/upgrade. In any of
+  // these cases, we want to unload the current code.
+  Main.unload();
 }
 
 function install(data, reason) {
@@ -25,7 +31,4 @@ function install(data, reason) {
 }
 
 function uninstall(data, reason) {
-  // uninstall / offboarding experience? ask for feedback?
-  // TODO: xhr the uninstall event to a server
-  Main.unload();
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -84,6 +84,7 @@ var unloadFromWindow = function(win) {
   win.gBrowser.tabContainer.removeEventListener('TabClose', onTabClose);
   win.US.urlbar.derender(win);
   win.US.popup.derender(win);
+
   // TODO: not sure these steps are technically necessary:
   // remove stylesheet
   // remove subscripts (not sure this is possible, can we just remove the app global?)

--- a/lib/ui/Popup.js
+++ b/lib/ui/Popup.js
@@ -24,6 +24,7 @@ function Popup() {
 Popup.prototype = {
   constructor: Popup,
   port: null,
+  browser: null,
   render:  function(win) {
     this.popup = win.document.createElementNS('http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul', 'panel');
     this.popup.setAttribute('type', 'autocomplete-richlistbox');
@@ -42,13 +43,16 @@ Popup.prototype = {
     // XXX: We aren't really initialized yet. We wait to set up the WebChannel
     //      until the browser element loads. It's an anonymous XUL node, so we
     //      wait until our XBL constructor is called, and it passes us the node.
+
+    // oh binding is fun
+    this.onBrowserLoaded = this.onBrowserLoaded.bind(this);
   },
   derender: function(win) {
     if (this.port) {
       this.port.stopListening();
     }
     // remove the load listener, in case uninstall happens before onBrowserLoaded fires
-    this.browser.removeEventListener('load', this.onBrowserLoaded.bind(this), true);
+    this.browser.removeEventListener('load', this.onBrowserLoaded, true);
     this.popupParent.removeChild(this.popup);
   },
   // Set the iframe src and wire up ready listener that will attach the WebChannel.
@@ -59,12 +63,12 @@ Popup.prototype = {
   setBrowser: function(browserEl) {
     if (this.rendered) { return; }
     this.browser = browserEl;
-    this.browser.addEventListener('load', this.onBrowserLoaded.bind(this), true);
+    this.browser.addEventListener('load', this.onBrowserLoaded, true);
     this.browser.setAttribute('src', this.frameURL + '?cachebust=' + Date.now());
   },
   // when the iframe is ready, load up the WebChannel
   onBrowserLoaded: function() {
-    this.browser.removeEventListener('load', this.onBrowserLoaded.bind(this), true);
+    this.browser.removeEventListener('load', this.onBrowserLoaded, true);
     this.browser.messageManager.loadFrameScript('chrome://browser/content/content.js', true);
 
     this.port = new WebChannel(this.channelID, Services.io.newURI(this.frameBaseURL, null, null));

--- a/lib/ui/Urlbar.js
+++ b/lib/ui/Urlbar.js
@@ -8,30 +8,43 @@ function Urlbar() {}
 Urlbar.prototype = {
   // replaced handlers and elements
   replaced: {},
+  isRendered: false,
   render: function(win) {
+    // needed to avoid overwriting the handlers by reapplying the .bind()
+    if (this.isRendered) { return; }
+    this.isRendered = true;
+
     this.urlbar = win.document.getElementById('urlbar');
     this.replaced._autocompletepopup = this.urlbar.getAttribute('autocompletepopup');
     this.urlbar.setAttribute('autocompletepopup', 'PopupAutoCompleteRichResultUnivSearch');
 
-    this.urlbar.addEventListener('focus', this.onFocus.bind(this));
-    this.urlbar.addEventListener('blur', this.onBlur.bind(this));
-    this.urlbar.addEventListener('keydown', this.onKeyDown.bind(this));
-    this.urlbar.addEventListener('keypress', this.onKeyPress.bind(this));
-    this.urlbar.addEventListener('mousedown', this.onMouseDown.bind(this));
-    this.urlbar.addEventListener('paste', this.onPaste.bind(this));
-    this.urlbar.addEventListener('drop', this.onDrop.bind(this));
+    this.urlbar.addEventListener('focus', this.onFocus);
+    this.urlbar.addEventListener('blur', this.onBlur);
+    this.urlbar.addEventListener('keydown', this.onKeyDown);
+    this.urlbar.addEventListener('keypress', this.onKeyPress);
+    this.urlbar.addEventListener('mousedown', this.onMouseDown);
+    this.urlbar.addEventListener('paste', this.onPaste);
+    this.urlbar.addEventListener('drop', this.onDrop);
+
+    // refresh the urlbar
+    this.urlbar.parentNode.insertBefore(this.urlbar, this.urlbar.nextSibling);
   },
   derender: function() {
-    this.urlbar.removeEventListener('focus', this.onFocus.bind(this));
-    this.urlbar.removeEventListener('blur', this.onBlur.bind(this));
-    this.urlbar.removeEventListener('keydown', this.onKeyDown.bind(this));
-    this.urlbar.removeEventListener('keypress', this.onKeyPress.bind(this));
-    this.urlbar.removeEventListener('mousedown', this.onMouseDown.bind(this));
-    this.urlbar.removeEventListener('paste', this.onPaste.bind(this));
-    this.urlbar.removeEventListener('drop', this.onDrop.bind(this));
-
     // reconnect original popup to the urlbar
     this.urlbar.setAttribute('autocompletepopup', this.replaced._autocompletepopup);
+
+    this.urlbar.removeEventListener('focus', this.onFocus);
+    this.urlbar.removeEventListener('blur', this.onBlur);
+    this.urlbar.removeEventListener('keydown', this.onKeyDown);
+    this.urlbar.removeEventListener('keypress', this.onKeyPress);
+    this.urlbar.removeEventListener('mousedown', this.onMouseDown);
+    this.urlbar.removeEventListener('paste', this.onPaste);
+    this.urlbar.removeEventListener('drop', this.onDrop);
+
+    // refresh the urlbar
+    this.urlbar.parentNode.insertBefore(this.urlbar, this.urlbar.nextSibling);
+
+    this.isRendered = false;
   },
   onFocus: function(evt) {},
   onBlur: function(evt) {},
@@ -40,7 +53,7 @@ Urlbar.prototype = {
   //       to rethink a bit.
   onKeyDown: function(evt) {
     console.log('Urlbar.onKeyDown');
-    var gURLBar = this.urlbar;
+    var gURLBar = window.US.urlbar;
     var gBrowser = window.gBrowser;
 
     if (evt.ctrlKey || evt.altKey || evt.metaKey) {


### PR DESCRIPTION
- correctly remove listeners by adjusting binding approach
- pull the urlbar in/out of the DOM to toggle XBL re-binding in both
  the Urlbar.render and Urlbar.derender methods
- make disabling work as well as uninstalling
- pop the urlbar node out of / into the DOM to rewire XBL bindings
  after install / uninstall
  
  Fixes #21.
