### PR TITLE
Issue 26 - add basic event logging.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -7,10 +7,12 @@ XPCOMUtils.defineLazyModuleGetter(this, 'Main',
   'chrome://universalsearch-lib/content/main.js');
 
 function startup(data, reason) {
+  console.log('bootstrap startup called');
   Main.load();
 }
 
 function shutdown(data, reason) {
+  console.log('bootstrap shutdown called');
   // no teardown is needed for a normal shutdown
   if (reason == APP_SHUTDOWN) { return; }
 
@@ -26,9 +28,11 @@ function shutdown(data, reason) {
 }
 
 function install(data, reason) {
+  console.log('bootstrap install called');
   // upsell? product tour? other first time experience?
   // TODO: xhr the install event to a server
 }
 
 function uninstall(data, reason) {
+  console.log('bootstrap uninstall called');
 }

--- a/lib/ui/Popup.js
+++ b/lib/ui/Popup.js
@@ -79,7 +79,7 @@ Popup.prototype = {
     var url;
     if (id != this.channelID) { return; }
     if (msg.type == 'autocomplete-url-clicked') {
-      console.log('autocomplete widget received "autocomplete-url-clicked" event');
+      console.log('browser received "autocomplete-url-clicked" event: ', msg);
       this.popup.hidePopup();
       if (msg.data.resultType == 'url') {
         // it's navigable, go for it
@@ -93,7 +93,7 @@ Popup.prototype = {
         window.gBrowser.loadURI(url);
       }
     } else if (msg.type == 'url-selected') {
-      console.log('autocomplete widget received "url-selected" event');
+      console.log('browser received "url-selected" event: ', msg);
       if (msg.data.resultType == 'url') {
         window.US.gURLBar.value = msg.data.result;
         window.US.gURLBar._search = null;
@@ -107,18 +107,24 @@ Popup.prototype = {
         url = engine.getSubmission(msg.data.result).uri.spec;
         window.US.gURLBar._search = { term: msg.data.result, url: url };
       }
+    } else {
+      console.log('browser received unrecognized event: ', msg);
     }
   },
   onPopupShowing: function() {
     if (!this.port) { return; }
-    this.port.send({ type: 'popupopen' }, {
+    var msg = { type: 'popupopen' };
+    console.log('browser sending message to iframe: ', msg);
+    this.port.send(msg, {
       browser: this.browser,
       principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
     });
   },
   onPopupHiding: function() {
     if (!this.port) { return; }
-    this.port.send({ type: 'popupclose' }, {
+    var msg = { type: 'popupclose' };
+    console.log('browser sending message to iframe: ', msg);
+    this.port.send(msg, {
       browser: this.browser,
       principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
     });
@@ -135,28 +141,43 @@ Popup.prototype = {
   },
   _appendCurrentResult: function() {
     var autocompleteResults = this._getAutocompleteSearchResults();
+    var autocompleteMsg = {
+      type: 'autocomplete-search-results',
+      data: autocompleteResults
+    };
+    var suggestedMsg = {
+      type: 'suggested-search-results',
+      data: {
+        results: []
+      }
+    };
+    // TODO: refactor
     this._getSearchSuggestions().then(function(searchSuggestions) {
-      console.log('sending over autocompleteResults: ',autocompleteResults);
-      this.port.send({ type: 'autocomplete-search-results', data: autocompleteResults }, {
+      console.log('browser sending message to iframe: ', autocompleteMsg);
+      this.port.send(autocompleteMsg, {
         browser: this.browser,
         principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
       });
+
       delete searchSuggestions.formHistoryResult;
-      console.log('sending over searchSuggestions: ',searchSuggestions);
-      this.port.send({ type: 'suggested-search-results', data: { results: searchSuggestions}}, {
+      suggestedMsg.data.results = searchSuggestions;
+      console.log('browser sending message to iframe: ', suggestedMsg);
+      this.port.send(suggestedMsg, {
         browser: this.browser,
         principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
       });
     }.bind(this), function(err) {
-      this.port.send({ type: 'autocomplete-search-results', data: autocompleteResults }, {
-        browser: this.browser,
-        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
-      });
-      this.port.send({ type: 'suggested-search-results', data: {results: []}}, {
-        browser: this.browser,
-        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
-      });
       Cu.reportError(err);
+      console.log('browser sending message to iframe: ', autocompleteMsg);
+      this.port.send(autocompleteMsg, {
+        browser: this.browser,
+        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+      });
+      console.log('browser sending message to iframe: ', suggestedMsg);
+      this.port.send(suggestedMsg, {
+        browser: this.browser,
+        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
+      });
     });
   },
   _getAutocompleteSearchResults: function() {

--- a/lib/ui/Urlbar.js
+++ b/lib/ui/Urlbar.js
@@ -58,11 +58,7 @@ Urlbar.prototype = {
 
     if (evt.ctrlKey || evt.altKey || evt.metaKey) {
       // special keys could mean a hotkey combination, so bail
-      // TODO: extract port from popup so that urlbar can use it too
-      US.popup.port.send({ type: 'popupclose' }, {
-        browser: US.popup.browser,
-        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
-      });
+      // popup will send the notification down to the iframe
       US.popup.popup.closePopup();
     } else if (['ArrowLeft', 'ArrowRight', 'Escape', 'Enter', 'Backspace'].indexOf(evt.key) > -1) {
       // if there was only one char in the urlbar, then the backspace will empty it out, so we should
@@ -89,21 +85,20 @@ Urlbar.prototype = {
       }
 
       // we need to close the popup; tell the iframe
-      US.popup.port.send({ type: 'popupclose' }, {
-        browser: US.popup.browser,
-        principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
-      });
+      // again, the popup listens for close events + sends the message to the iframe
       US.popup.popup.closePopup();
     } else if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Tab'].indexOf(evt.key) > -1) {
       // TODO: either duplicate or simply reuse the remaining key handling behavior below, like the bit
       // where we ignore keys that are part of a keyboard shortcut
-      US.popup.port.send({
+      var msg = {
         type: 'navigational-key',
         data: {
           key: evt.key,
           shiftKey: evt.shiftKey
         }
-      }, {
+      };
+      console.log('browser sending message to iframe: ',msg);
+      US.popup.port.send(msg, {
         browser: US.popup.browser,
         principal: Cc["@mozilla.org/systemprincipal;1"].createInstance(Ci.nsIPrincipal)
       });
@@ -111,9 +106,7 @@ Urlbar.prototype = {
 
     // TODO: pull in the other handler behavior
   },
-  onKeyPress: function(evt) {
-    console.log('Urlbar.onKeyPress');
-  },
+  onKeyPress: function(evt) {},
   onMouseDown: function(evt) {},
   onPaste: function(evt) {},
   onDrop: function(evt) {}


### PR DESCRIPTION
  We now log:
    - the basic restartless addon lifecycle events,
    - every event sent to the iframe,
    - every event received from the iframe.

  These can be viewed inside the Browser Console or Browser Toolkit
  console.

  Fixes #26.
