### PR TITLE
Issue 36 - Fix handling of Enter in urlbar.

### DIFF
--- a/lib/ui/Urlbar.js
+++ b/lib/ui/Urlbar.js
@@ -53,7 +53,8 @@ Urlbar.prototype = {
   //       to rethink a bit.
   onKeyDown: function(evt) {
     console.log('Urlbar.onKeyDown');
-    var gURLBar = window.US.urlbar;
+
+    var gURLBar = window.gURLBar;
     var gBrowser = window.gBrowser;
 
     if (evt.ctrlKey || evt.altKey || evt.metaKey) {
@@ -75,8 +76,8 @@ Urlbar.prototype = {
           // the user selected a search suggestion via keypresses, then hit enter.
           // we know the suggestion is not stale, because it matches the current contents
           // of the urlbar. So, navigate to the hidden search URL that corresponds to the term.
-          gBrowser.loadURI(gURLBar.search.url);
-          gURLBar.search = null;
+          gBrowser.loadURI(gURLBar._search.url);
+          gURLBar._search = null;
         } else {
           // hmm, when we key over non-search values, hitting enter doesn't quite work.
           // maybe just surf to whatever's in the urlbar?


### PR DESCRIPTION
  Fixing two bugs in one commit:

  First, I was setting gURLBar = window.US.urlbar, but that's my Urlbar
  object, not the gURLBar we actually want.

  Second, a busted refactoring is at work. gURLBar._search is a property
  that I cavalierly set on gURLBar, in order to track state across
  searches. This is not needed in our addon, but rather a hack that I
  used when hacking on gecko at ludicrous speed. I refactored Popup from
  gURLBar.search to gURLBar._search, but didn't also update the refs in
  Urlbar's gURLBar.search checks, which happen to be in the Enter key
  handler.

  Fixes #36.
