### PR TITLE
Dedupe messages at the Transport layer.

### DIFF
--- a/src/lib/Transport.js
+++ b/src/lib/Transport.js
@@ -18,6 +18,8 @@ function Transport() {
                         prefBranch.getCharPref('services.universalSearch.baseURL') :
                         'https://d1fnkpeapwua2i.cloudfront.net';
   this.port = null;
+  this._lastAutocompleteSearchTerm = '';
+  this._lastSuggestedSearchTerm = '';
 }
 
 Transport.prototype = {
@@ -56,10 +58,27 @@ Transport.prototype = {
     if (id !== this.channelID) { return; }
     window.US.broker.publish('iframe::' + msg.type, msg.data);
   },
+  // Dedupe sequential messages if the user input hasn't changed. See #18 and
+  // associated commit message for gnarly details.
+  //
+  // Note, there is some duplication in the deduping logic in these two fns.
+  // However, I'm not sure the result of functional decomposition (extracting
+  // the dedupe function into a memoize-like combinator) would actually yield
+  // more understandable or readable code than what we've got here. :-\
   onAutocompleteSearchResults: function(msg) {
+    var currentInput = msg && msg.length && msg[0].text;
+    if (currentInput && currentInput == this._lastAutocompleteSearchTerm) {
+      return;
+    }
+    this._lastAutocompleteSearchTerm = currentInput;
     this.sendMessage('autocomplete-search-results', msg);
   },
   onSuggestedSearchResults: function(msg) {
+    var currentInput = msg && msg.term;
+    if (currentInput && currentInput == this._lastSuggestedSearchTerm) {
+      return;
+    }
+    this._lastSuggestedSearchTerm = currentInput;
     this.sendMessage('suggested-search-results', { results: msg });
   },
   onNavigationalKey: function(msg) {


### PR DESCRIPTION
  Unfortunately, nsAutoCompleteController.cpp is calling its OpenPopup
  method (which calls the XBL openPopup setter on the base popup)
  multiple times, depending on how many chars are in the urlbar. For
  example, going from 'a' to 'ab' seems to fire 2 or 3 events.

  We could dedupe based on checking the string in the urlbar, but I
  don't trust my understanding of XUL DOM (and XBL's DOM binding bugs)
  well enough to know if we'd just wind up introducing weird race
  conditions. The potential downside might be that the popup wouldn't
  open sometimes when it should.

  The quickest solution here is to just dedupe at the transport layer:
  if we've sent a packet corresponding to a given string typed by the
  user, don't send more packets generated from the same input string.

  Longer-term, we might stop using the existing autocomplete controller
  and just implement our own. If we decide to use different queries over
  the Places DB, or if we use an alternative SQLite DB, we'll need to do
  that anyway.

  For now, opting to go with the quick fix.

  Closes #18.
