### PR TITLE
Revert "Generate the src/*.rdf files from a template"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 dist
 *.log
-src/*.rdf

--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ To work around this:
 1. Restart the browser, and you're in business.
 
 ## Release process:
+  1. Manually bump the version number in `src/install.rdf` and `src/update.rdf`.
   1. Bump the version number in package.json using `npm version patch`. This will generate a git tag, too.
-  1. Generate the src/install.rdf and src/update.rdf files, and zip up a new addon: `gulp build`.
+  1. Zip up a new addon: `gulp build`.
   1. Release the addon to people: `scp dist/addon.xpi jhirsch@people.mozilla.org:public_html/universal-search-addon/addon.xpi`
-  1. Release the dist/update.rdf file to people: `scp dist/update.rdf jhirsch@people.mozilla.org:public_html/universal-search-addon/update.rdf`
+  1. Release the src/update.rdf file to people: `scp src/update.rdf jhirsch@people.mozilla.org:public_html/universal-search-addon/update.rdf`
   1. Probably email the universal-search list?
 
 ## Useful Snippets

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,45 +1,24 @@
 const del = require('del');
 const eslint = require('gulp-eslint');
 const gulp = require('gulp');
-const template = require('gulp-template');
 const zip = require('gulp-zip');
 
-const pkgVersion = require('./package.json').version;
+gulp.task('build', ['lint', 'clean:dist'], function () {
+  return gulp.src('src/**')
+    .pipe(zip('addon.xpi'))
+    .pipe(gulp.dest('dist'));
+});
 
-// Delete everything in the `dist/*` directory.
 gulp.task('clean:dist', function (callback) {
   del(['dist'], callback);
 });
 
-// Copy the `src/*.rdf` files to `dist/*.rdf` for easier deployment.
-gulp.task('copy:rdf', ['generate:rdf'], function () {
-  return gulp.src('src/*.rdf')
-    .pipe(gulp.dest('dist'));
-});
-
-// Run ESLint against all the *.js files.
 gulp.task('eslint', function () {
   return gulp.src('{,src/**/,test/**/}*.js')
     .pipe(eslint())
     .pipe(eslint.failOnError());
 });
 
-// Generate the `src/install.rdf` and `src/update.rdf` files from the templates.
-gulp.task('generate:rdf', function () {
-  return gulp.src('templates/*.rdf')
-    .pipe(template({version: pkgVersion}))
-    .pipe(gulp.dest('src'));
-});
-
-// Generate the `dist/addon.xpi` file from the files in `src/**`.
-gulp.task('generate:xpi', function () {
-  return gulp.src('src/**')
-    .pipe(zip('addon.xpi'))
-    .pipe(gulp.dest('dist'));
-});
-
-gulp.task('build', ['lint', 'clean:dist', 'copy:rdf', 'generate:xpi']);
-
 gulp.task('lint', ['eslint']);
 
-gulp.task('default', ['build']);
+gulp.task('default', ['lint']);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "eslint-config-universal-search": "1.0.0",
     "gulp": "3.9.0",
     "gulp-eslint": "0.15.0",
-    "gulp-template": "3.0.0",
     "gulp-zip": "3.0.2",
     "mocha": "2.2.5",
     "sinon": "1.15.4"

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -7,7 +7,7 @@
     <em:type>2</em:type>
 
     <em:unpack>false</em:unpack>
-    <em:version><%= version %></em:version>
+    <em:version>1.1</em:version>
     <em:name>Universal Search Addon</em:name>
     <em:description>Universal Search desktop FF experiments in addon format</em:description>
     <em:creator/>

--- a/src/update.rdf
+++ b/src/update.rdf
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RDF:RDF xmlns:RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+  <!-- TODO: use a templating library to auto-generate this file from various config values,
+             rather than hard-coding stuff here and in the addon -->
   <RDF:Description about="urn:mozilla:extension:universal-search-addon@mozilla.com">
     <em:updates>
       <RDF:Seq>
@@ -8,7 +10,7 @@
         <!-- docs suggest one li per version of the addon...what if we just update all to latest? -->
         <RDF:li>
           <RDF:Description>
-            <em:version><%= version %></em:version>
+            <em:version>1.1</em:version>
             <em:targetApplication>
               <RDF:Description>
                 <!-- desktop FF UUID -->


### PR DESCRIPTION
This reverts commit f5b7465a56ef2c49eeeba33a9e8c259246812f2a.

We need a static install.rdf in the src directory, or else you can't use a proxy file to run this locally. We'll try again later.
