### PR TITLE
Converting == to === in Transport.js, and add prepush Git hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   },
   "devDependencies": {
     "del": "1.2.0",
-    "eslint": "0.24.0",
     "eslint-config-universal-search": "1.0.0",
     "gulp": "3.9.0",
     "gulp-eslint": "0.15.0",
     "gulp-zip": "3.0.2",
+    "husky": "0.9.1",
     "mocha": "2.2.5",
     "sinon": "1.15.4"
   },
@@ -33,6 +33,7 @@
   "scripts": {
     "build": "gulp build",
     "lint": "gulp lint",
+    "prepush": "npm run lint",
     "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/src/lib/Transport.js
+++ b/src/lib/Transport.js
@@ -67,7 +67,7 @@ Transport.prototype = {
   // more understandable or readable code than what we've got here. :-\
   onAutocompleteSearchResults: function(msg) {
     var currentInput = msg && msg.length && msg[0].text;
-    if (currentInput && currentInput == this._lastAutocompleteSearchTerm) {
+    if (currentInput && currentInput === this._lastAutocompleteSearchTerm) {
       return;
     }
     this._lastAutocompleteSearchTerm = currentInput;
@@ -75,7 +75,7 @@ Transport.prototype = {
   },
   onSuggestedSearchResults: function(msg) {
     var currentInput = msg && msg.term;
-    if (currentInput && currentInput == this._lastSuggestedSearchTerm) {
+    if (currentInput && currentInput === this._lastSuggestedSearchTerm) {
       return;
     }
     this._lastSuggestedSearchTerm = currentInput;


### PR DESCRIPTION
Strict Equality Rules Everything Around Me

Otherwise we get this (currently in **master**):

```
➜  universal-search-addon git:(master) npm run lint

> mozilla-universal-search-addon@1.1.0 lint /Users/pdehaan/dev/github/universal-search-addon
> gulp lint

[15:26:51] Using gulpfile ~/dev/github/universal-search-addon/gulpfile.js
[15:26:51] Starting 'eslint'...
[15:26:52] 'eslint' errored after 234 ms
[15:26:52] ESLintError in plugin 'gulp-eslint'
Message:
    Expected '===' and instead saw '=='.
Details:
    fileName: /Users/pdehaan/dev/github/universal-search-addon/src/lib/Transport.js
    lineNumber: 70

npm ERR! Darwin 14.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "run" "lint"
npm ERR! node v0.10.35
npm ERR! npm  v3.1.1
npm ERR! code ELIFECYCLE
npm ERR! mozilla-universal-search-addon@1.1.0 lint: `gulp lint`
npm ERR! Exit status 1
```
