### PR TITLE
Release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mozilla-universal-search-addon",
   "description": "universal search desktop experiments in addon format",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Mozilla (https://mozilla.org/)",
   "bugs": {
     "url": "https://github.com/mozilla/universal-search-addon/issues"

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -7,7 +7,7 @@
     <em:type>2</em:type>
 
     <em:unpack>false</em:unpack>
-    <em:version>1.1</em:version>
+    <em:version>2.0</em:version>
     <em:name>Universal Search Addon</em:name>
     <em:description>Universal Search desktop FF experiments in addon format</em:description>
     <em:creator/>

--- a/src/update.rdf
+++ b/src/update.rdf
@@ -10,7 +10,7 @@
         <!-- docs suggest one li per version of the addon...what if we just update all to latest? -->
         <RDF:li>
           <RDF:Description>
-            <em:version>1.1</em:version>
+            <em:version>2.0</em:version>
             <em:targetApplication>
               <RDF:Description>
                 <!-- desktop FF UUID -->


### PR DESCRIPTION
dun dun dun

Bump major version because we introduce a non-backwards-compatible API change, handling Enter keys via `url-selected` events of type `empty`.
