### PR TITLE
Remove duplicated tasks in gulpfile.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+users.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.log
+users.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const del = require('del');
 const eslint = require('gulp-eslint');
 const gulp = require('gulp');
-const zip = require('gulp-zip');
 const template = require('gulp-template');
+const zip = require('gulp-zip');
 
 const pkgVersion = require('./package.json').version;
 
@@ -25,10 +25,6 @@ gulp.task('eslint', function () {
     .pipe(eslint())
     .pipe(eslint.failOnError());
 });
-
-gulp.task('lint', ['eslint']);
-
-gulp.task('default', ['lint']);
 
 gulp.task('gen-prefs', function(cb){
   var contents = '// Set prefs to use a local content server\n'; // eslint-disable-line


### PR DESCRIPTION
Fixes #87 

Also noticed that if you ran `gulp gen-prefs` that it'd create a `/users.js` file in your project folder, so I added that to .gitignore since we probably don't want that back in GitHub. Then I noticed that our `gulp lint` task tries to lint that users.js file and fails, so was stopping my Git pre-push hook, so I also added it to .eslintignore since we don't care.
