### PR TITLE
Issue 93 xbl fixes

### DIFF
--- a/src/chrome/content/content.xml
+++ b/src/chrome/content/content.xml
@@ -12,9 +12,10 @@
     <implementation>
        <constructor>
         <![CDATA[
+          // JS cannot access XBL-created anonymous elements, so we have to
+          // pass the element pointer in this way
           this.browser = document.getAnonymousElementByAttribute(this, 'anonid', 'infect-and-destroy');
-          // TODO: do we really need to do this?
-          US.popup.setBrowser(this.browser);
+          US.browser = this.browser;
         ]]>
       </constructor>
       <property name="selectedIndex"

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -78,12 +78,6 @@ const loadIntoWindow = function(win) {
   // that appears when you type in the urlbar)
   win.US.goButton = new win.GoButton();
   win.US.goButton.render(win);
-
-  // we call this function when the XBL loads, so we can get a pointer to the
-  // anonymous browser element.
-  win.US.setBrowser = function(browserEl) {
-    win.US.browser = browserEl;
-  };
 };
 
 // basically reverse the loadIntoWindow function

--- a/templates/install.rdf
+++ b/templates/install.rdf
@@ -22,7 +22,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>38.0</em:minVersion>
-        <em:maxVersion>42.*</em:maxVersion>
+        <em:maxVersion>*</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>

--- a/templates/update.rdf
+++ b/templates/update.rdf
@@ -18,7 +18,7 @@
                 <!-- desktop FF UUID -->
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
                 <em:minVersion>38.0</em:minVersion>
-                <em:maxVersion>42.*</em:maxVersion>
+                <em:maxVersion>*</em:maxVersion>
                 <em:updateLink>https://people.mozilla.org/~jhirsch/universal-search-addon/addon.xpi</em:updateLink>
               </RDF:Description>
             </em:targetApplication>


### PR DESCRIPTION
The important stuff here is given in the bigger commit's log:

Change how XBL and JS interact on startup.
- Simplify XBL's role: just set the browser el on the window.US app
  global (which is, thankfully, accessible from XBL's scope)
- Simplify Popup startup: if the browser property isn't available,
  poll in a tight setTimeout loop until it is.
