### PR TITLE
Send individual keys to the iframe via printable-key event

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,7 @@ For each of these events, the general packet format is `{ type, data }`, where `
     * [`suggested-search-results`](#suggested-search-results)
   * UI events
     * [`navigational-key`](#navigational-key)
+    * [`printable-key`](#printable-key)
     * [`popupopen`](#popupopen)
     * [`popupclose`](#popupclose)
 * Content to Addon
@@ -79,6 +80,20 @@ Use `shiftKey` to decide if a `Tab` key corresponds to a shift-Tab or a Tab.
   key: event.key value for the key event, one of 'Tab', 'PageUp', 'PageDown',
        'ArrowUp', 'ArrowDown', 'Enter'
   shiftKey: true if the shift key is pressed
+}
+```
+
+### `printable-key`
+
+This event is sent when the user types a printable key (that is, a non-navigational key) in the address bar, or when the user hits Backspace (to update the iframe-delivered suggestion).
+
+This event allows the iframe to use additional servers to generate suggested results.
+
+It might be a bit of a misleading event name, since what we actually care about is sending over the contents of the urlbar. For instance, if the user inserted a character in the middle of a word in the urlbar, or if the user deletes a character in the middle of a phrase, it's much simpler to send over the new contents, than to send the change event with a position into the string.
+
+```
+{
+  query: current contents of the urlbar
 }
 ```
 

--- a/src/lib/Transport.js
+++ b/src/lib/Transport.js
@@ -36,6 +36,8 @@ Transport.prototype = {
                                this.onSuggestedSearchResults, this);
     window.US.broker.subscribe('urlbar::navigationalKey',
                                this.onNavigationalKey, this);
+    window.US.broker.subscribe('urlbar::printableKey',
+                               this.onPrintableKey, this);
 
     this.port = new WebChannel(this.channelId,
                                Services.io.newURI(this.frameBaseURL, null, null));
@@ -54,6 +56,8 @@ Transport.prototype = {
                                  this.onSuggestedSearchResults, this);
     window.US.broker.unsubscribe('urlbar::navigationalKey',
                                  this.onNavigationalKey, this);
+    window.US.broker.unsubscribe('urlbar::printableKey',
+                               this.onPrintableKey, this);
   },
   onContentMessage: function(id, msg, sender) {
     if (id !== this.channelId) { return; }
@@ -84,6 +88,9 @@ Transport.prototype = {
   },
   onNavigationalKey: function(msg) {
     this.sendMessage('navigational-key', msg);
+  },
+  onPrintableKey: function(msg) {
+    this.sendMessage('printable-key', msg);
   },
   onPopupOpen: function(msg) {
     this.sendMessage('popupopen');


### PR DESCRIPTION
  This new message allows the iframe to generate its own suggestions as
  the user types.

  Note that, in private browsing mode, this new signal will not be sent.
