### PR TITLE
Rename all uses of `users.js` to `user.js`.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-users.js
+user.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 dist
 *.log
-users.js
+user.js

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ These steps come from the [extension dev page](https://developer.mozilla.org/en-
 ### Setup specific to this addon
 1. If you're hacking on the [iframe](https://github.com/mozilla/universal-search-content), then configure your profile to use a local copy:
   - Run `gulp gen-prefs`
-    - creates a file named `users.js`
-    - move this file to your Firefox profile directory, e.g. `/path/to/ff/Profiles/6h6ygzlo.addon-dev/users.js`
+    - creates a file named `user.js`
+    - move this file to your Firefox profile directory, e.g. `/path/to/ff/Profiles/6h6ygzlo.addon-dev/user.js`
 1. The first time you use a local iframe, you'll probably be serving it from `https://localhost:8080/`. You will get a security warning, it'll look something like this: ![](https://www.dropbox.com/s/9ieyvpimtfkmqo4/Screenshot%202015-07-21%2014.52.10.png?dl=0&raw=true)
 To work around this:
   - Surf to the iframe URL (**the enter key won't work**. You will have to click the Go Button, the little right arrow at the edge of the address bar)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ gulp.task('gen-prefs', function(cb){
   contents += '\n// Set prefs using remote content server\n';
   contents += '//user_pref("services.universalSearch.frameURL", "https://d1fnkpeapwua2i.cloudfront.net/index.html");\n';
   contents += '//user_pref("services.universalSearch.baseURL", "https://d1fnkpeapwua2i.cloudfront.net/");\n';
-  fs.writeFile('users.js', contents, cb);
+  fs.writeFile('user.js', contents, cb);
 });
 
 // Generate the `src/install.rdf` and `src/update.rdf` files from the templates.


### PR DESCRIPTION
`users.js` doesn't appear to do anything, but `user.js` does. Lines up with this doc as well: http://kb.mozillazine.org/User.js_file

r? @6a68 
