### PR TITLE
Fix #128: Convert inner fns to fat arrows & remove JS module globals

### DIFF
--- a/src/lib/Broker.js
+++ b/src/lib/Broker.js
@@ -30,6 +30,7 @@ Broker.prototype = {
   _eventExists: function(evt) {
     return evt in this._subscribers;
   },
+  shutdown: function() {},
   subscribe: function(evt, cb, thisArg) {
     if (!this._isValidEvent(evt)) {
       throw new TypeError('called subscribe with invalid event name ' + evt);
@@ -42,7 +43,7 @@ Broker.prototype = {
     }
 
     let exists;
-    this._subscribers[evt].forEach(function(subscriber) {
+    this._subscribers[evt].forEach((subscriber) => {
       if (subscriber.cb === cb && subscriber.thisArg === thisArg) {
         exists = true;
       }
@@ -62,7 +63,7 @@ Broker.prototype = {
       throw new TypeError('called unsubscribe for unknown event ' + evt);
     }
 
-    this._subscribers[evt].forEach(function(subscribed, i) {
+    this._subscribers[evt].forEach((subscribed, i) => {
       if (subscribed.cb === cb && subscribed.thisArg === thisArg) {
         this._subscribers[evt].splice(i, 1);
       }
@@ -79,7 +80,7 @@ Broker.prototype = {
       throw new TypeError('called publish with invalid event name ' + evt);
     }
 
-    this._subscribers[evt].forEach(function(subscriber) {
+    this._subscribers[evt].forEach((subscriber) => {
       subscriber.cb.apply(subscriber.thisArg, args);
     });
   }

--- a/src/lib/Transport.js
+++ b/src/lib/Transport.js
@@ -19,10 +19,8 @@ XPCOMUtils.defineLazyModuleGetter(this, 'WebChannel',
 XPCOMUtils.defineLazyModuleGetter(this, 'console',
   'resource://gre/modules/devtools/Console.jsm');
 
-let app;
-
 function Transport(appGlobal) {
-  app = appGlobal;
+  this.app = appGlobal;
 
   const prefBranch = Cc['@mozilla.org/preferences-service;1']
                    .getService(Ci.nsIPrefService)
@@ -41,15 +39,15 @@ Transport.prototype = {
   constructor: Transport,
   init: function() {
     // intentionally alphabetized
-    app.broker.subscribe('popup::autocompleteSearchResults',
+    this.app.broker.subscribe('popup::autocompleteSearchResults',
                                this.onAutocompleteSearchResults, this);
-    app.broker.subscribe('popup::popupClose', this.onPopupClose, this);
-    app.broker.subscribe('popup::popupOpen', this.onPopupOpen, this);
-    app.broker.subscribe('popup::suggestedSearchResults',
+    this.app.broker.subscribe('popup::popupClose', this.onPopupClose, this);
+    this.app.broker.subscribe('popup::popupOpen', this.onPopupOpen, this);
+    this.app.broker.subscribe('popup::suggestedSearchResults',
                                this.onSuggestedSearchResults, this);
-    app.broker.subscribe('urlbar::navigationalKey',
+    this.app.broker.subscribe('urlbar::navigationalKey',
                                this.onNavigationalKey, this);
-    app.broker.subscribe('urlbar::printableKey',
+    this.app.broker.subscribe('urlbar::printableKey',
                                this.onPrintableKey, this);
 
     this.port = new WebChannel(this.channelId,
@@ -61,20 +59,20 @@ Transport.prototype = {
       this.port.stopListening();
     }
 
-    app.broker.unsubscribe('popup::autocompleteSearchResults',
+    this.app.broker.unsubscribe('popup::autocompleteSearchResults',
                                  this.onAutocompleteSearchResults, this);
-    app.broker.unsubscribe('popup::popupClose', this.onPopupClose, this);
-    app.broker.unsubscribe('popup::popupOpen', this.onPopupOpen, this);
-    app.broker.unsubscribe('popup::suggestedSearchResults',
+    this.app.broker.unsubscribe('popup::popupClose', this.onPopupClose, this);
+    this.app.broker.unsubscribe('popup::popupOpen', this.onPopupOpen, this);
+    this.app.broker.unsubscribe('popup::suggestedSearchResults',
                                  this.onSuggestedSearchResults, this);
-    app.broker.unsubscribe('urlbar::navigationalKey',
+    this.app.broker.unsubscribe('urlbar::navigationalKey',
                                  this.onNavigationalKey, this);
-    app.broker.unsubscribe('urlbar::printableKey',
+    this.app.broker.unsubscribe('urlbar::printableKey',
                                this.onPrintableKey, this);
   },
   onContentMessage: function(id, msg, sender) {
     if (id !== this.channelId) { return; }
-    app.broker.publish('iframe::' + msg.type, msg.data);
+    this.app.broker.publish('iframe::' + msg.type, msg.data);
   },
   // Dedupe sequential messages if the user input hasn't changed. See #18 and
   // associated commit message for gnarly details.
@@ -118,7 +116,7 @@ Transport.prototype = {
     };
     console.log('sending the ' + evt + ' message to content:' + JSON.stringify(msg));
     const ctx = {
-      browser: app.browser,
+      browser: this.app.browser,
       principal: Cc['@mozilla.org/systemprincipal;1']
                  .createInstance(Ci.nsIPrincipal)
     };

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -123,15 +123,19 @@ const unloadFromWindow = function(win) {
   delete win.US;
 };
 
+function onWindowLoaded(evt) {
+  // Gecko forces us to do unseemly things to obtain a XUL window reference
+  const win = evt.target.ownerGlobal;
+  win.removeEventListener('load', onWindowLoaded, false);
+  if (win.location.href === 'chrome://browser/content/browser.xul') {
+    loadIntoWindow(win);
+  }
+}
+
 function onWindowNotification(win, topic) {
   if (topic !== 'domwindowopened') { return; }
   console.log('iterating windows');
-  win.addEventListener('load', function loader() {
-    win.removeEventListener('load', loader, false);
-    if (win.location.href === 'chrome://browser/content/browser.xul') {
-      loadIntoWindow(win);
-    }
-  }, false);
+  win.addEventListener('load', onWindowLoaded, false);
 }
 
 function load() {


### PR DESCRIPTION
Several inner functions had scoping issues due to improper `this`
binding. Replace those functions with anonymous arrow functions, or pull
them out to named, top-level functions in cases where the function needs
to be unregistered. Use .bind in the bizarre case of a callback invoked
by XBL with a really weird global object (see code comments for all the
feels).

Convert module globals to instance properties. Module-global occurrences
of the `app` and `win` variables were not removed in the switch to the
Firefox module loader. Because the modules are cached after the first
load, those `app` and `win` globals were being overwritten with a
reference to the most-recently-opened window, breaking the popup in all
the other windows.

Add a `shutdown` method to Broker, fixing the proximate cause of #128.

These improvements also fix #129 and fix #130.
