### PR TITLE
Use direct Places query instead of autocomplete service.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -27,11 +27,11 @@ For each of these events, the general packet format is `{ type, data }`, where `
 
 This event contains autocomplete search results pulled from the Places DB, as well as the search term.
 
-When the user types something in the address bar, the autocomplete search service looks through history/bookmarks/other unknown local stuff, and comes up with a list of results. The results are then sent down inside this event.
+When the user types something in the address bar, we look for matches in history and bookmarks by running a Places query based on the existing autocomplete code. Note that the search only covers local history; synced data from remote browsers isn't included. The results are then sent down inside this event.
 
 Note: if no results are returned, the results array will be empty.
 
-Note: the current max number of results returned is 5; I made this up, it's trivial to change it.
+Note: the current max number of results returned is 20; I made this up, it's trivial to change it.
 
 ```
 { results: array of result objects }
@@ -39,11 +39,18 @@ Note: the current max number of results returned is 5; I made this up, it's triv
 result:
 {
   url: the page URL, which might be a browser-specific thing like "about:blank"
-       or "moz-action:switchtab,http://example.com"
   title: page title
-  image: favicon URL (or null, if the browser has no favicon)
-  type: "bookmark" or "favicon" or "action favicon"...I don't know what these mean,
-        maybe they are classes used in styling the xul list items?
+  image: favicon URL
+  imageData: favicon image as Base64 data-uri (or null, if the file isn't cached)
+  type: 'action' if the page is open,
+        'bookmark' if the page is bookmarked,
+        'favicon' otherwise.
+        Originally based on XUL styling rules for the old popup.
+  open: true if the page is currently open
+  bookmark: null if not bookmarked, else an object of the form: {
+    title: possibly user-edited title for the bookmarked page
+    tags: user-created tags, if any, for the bookmarked page
+  }
   text: the search term in the address bar
 }
 ```

--- a/src/chrome/content/content.xml
+++ b/src/chrome/content/content.xml
@@ -6,29 +6,49 @@
           xmlns:xbl="http://www.mozilla.org/xbl">
   <binding id="autocomplete-rich-result-popup-univ-search" extends="chrome://global/content/bindings/autocomplete.xml#autocomplete-rich-result-popup">
     <content ignorekeys="false" level="top" consumeoutsideclicks="false">
+      <!-- The XBL startup process and the JS+DOM startup process race to
+           completion, and we need to listen for the load event fired by
+           the framed page.
+
+           In order to force initialization to happen in a predictable order,
+           we insert an empty <browser> node here; then in the <constructor>
+           below, we pass the JS side a reference to the browser element; on
+           the JS side, we poll until the browser el is visible, and then set
+           the browser el's src, starting the window load process. See the
+           lib/ui/Popup#render() method for more.
+      -->
       <xul:browser anonid="infect-and-destroy" type="content" height="366" minheight="366" flex="1" />
     </content>
 
     <implementation>
        <constructor>
         <![CDATA[
-          // JS cannot access XBL-created anonymous elements, so we have to
-          // pass the element pointer in this way
-          this.browser = document.getAnonymousElementByAttribute(this, 'anonid', 'infect-and-destroy');
-          US.browser = this.browser;
+          // JS cannot access XBL-created anonymous elements, but XBL can get
+          // and set global properties of the same window object visible to JS,
+          // and the window.US global set by lib/main.js seems to be available
+          // consistently before this constructor is invoked. So, we expose the
+          // browser element to the Popup JS initialization code by setting
+          // `US.browser` to that element.
+          //
+          US.browser = document.getAnonymousElementByAttribute(this, 'anonid', 'infect-and-destroy');
         ]]>
       </constructor>
       <property name="selectedIndex"
                 onget="return 0;">
         <setter>
           <![CDATA[
-            // override inherited method
+            // Override inherited method to avoid errors being thrown by the
+            // super method checking `this.tree.currentIndex`. Our popup
+            // implementation doesn't have `this.tree`, because we replace the
+            // inherited popup contents with a single <browser> element.
           ]]>
         </setter>
       </property>
       <method name="_invalidate">
         <body>
           <![CDATA[
+            // The inherited method calls _appendCurrentResult and recalculates
+            // the richlistbox height. Override, removing the XUL DOM code.
             this._appendCurrentResult();
           ]]>
         </body>
@@ -38,26 +58,52 @@
         <parameter name="aElement"/>
         <body>
           <![CDATA[
-          if (!this.mPopupOpen) {
-            this.mInput = aInput;
-            this._invalidate();
+            // Override inherited method, keeping the code that calculates the
+            // width of the popup (which we still use), but removing references
+            // to this.view (an nsITreeView we've removed). As always, we are
+            // forced to override parts of code via copy and paste, because the
+            // methods in the parent class are really, really long.
+            // TODO: the width calculation code has gotten an update with the
+            // unified complete work. Investigate changing ours to match.
+            if (!this.mPopupOpen) {
+              this.mInput = aInput;
+              this._invalidate();
 
-            var width = aElement.getBoundingClientRect().width;
-            this.setAttribute("width", width > 500 ? width : 500);
-            this.openPopup(aElement, "after_start", 0, 0, false, true);
-          }
+              var width = aElement.getBoundingClientRect().width;
+              this.setAttribute("width", width > 500 ? width : 500);
+              this.openPopup(aElement, "after_start", 0, 0, false, true);
+            }
         ]]>
         </body>
       </method>
-
       <method name="_appendCurrentResult">
         <body>
           <![CDATA[
-            // override inherited method
+            // We want to override this method with a method that runs in
+            // the more predictable, documented, and familiar JS+DOM
+            // environment. Oddly, we'll do this DOM Level 0 style, in the
+            // lib/ui/Popup render method, by assigning
+            // browser._appendCurrentResult to a JS-defined method.
+            //
+            // Because we don't want to override the method in the superclass,
+            // which is also the parent of the form field autocomplete UI, we
+            // create an _appendCurrentResult on our subclass by creating an
+            // empty no-op method here, on the XBL side. (Clearly there is a
+            // kind of prototypal inheritance at work, though exactly how it
+            // works is poorly documented, and XBL itself is an unspecified
+            // language.)
           ]]>
         </body>
       </method>
-
+      <method name="onSearchBegin">
+        <body>
+          <![CDATA[
+            // Override another inherited method to avoid throwing: the super
+            // method tries to access a property of `this.richlistbox`, another
+            // XUL element our popup doesn't have.
+          ]]>
+        </body>
+      </method>
     </implementation>
   </binding>
 </bindings>

--- a/src/lib/PlacesSearch.js
+++ b/src/lib/PlacesSearch.js
@@ -1,0 +1,291 @@
+'use strict';
+
+// This class searches the Places DB for us, answering these questions:
+// - Given a user-typed string, are there matching history entries?
+// - Given a retrieved history entry, is it a bookmark? a currently-open tab?
+//
+// Our main query is a simplified version of the default query used in the
+// existing autocomplete code, which is very similar across both the new
+// (UnifiedComplete) and old (nsPlacesAutoComplete) implementations in FF.
+//
+// Non-optimizations to consider when/if we optimize for performance:
+// - Existing code stores its own list of all open windows in an in-memory
+//   SQLite table. I have no idea how the performance compares to just using
+//   the global list of windows/tabs maintained by nsSessionStore.
+// - We don't worry about Places keywords or tags. This includes ignoring
+//   special characters like '^', which can be used to limit searches to
+//   subsets of history--definitely not a mainstream feature.
+// - We don't worry about adaptive searches, or really, nearly any of the
+//   edge cases explicitly considered here:
+//   https://dxr.mozilla.org/mozilla-central/source/ (url continues)
+//     toolkit/components/places/UnifiedComplete.js#865-874
+// - UnifiedComplete does large multi-joins, rather than a series of simple
+//   queries. I'm not sure what performance gains are possible with
+//   more complex queries, but I don't expect much from SQLite in terms of
+//   query planning and execution. We also don't have a remote DB, so the
+//   common network latency issues don't apply. Basically, it'll be neat
+//   to get some hard numbers around this later.
+// - We don't worry about whether a query was typed by the user or not.
+//   This corresponds to BOOKMARKED_HOST_QUERY and related constants in the
+//   existing code.
+
+/* global Components, PlacesUtils, SessionStore, Task, XPCOMUtils */
+
+const {utils: Cu, interfaces: Ci} = Components;
+
+Cu.import('resource://gre/modules/XPCOMUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'console',
+  'resource://gre/modules/devtools/Console.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'PlacesUtils',
+  'resource://gre/modules/PlacesUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'SessionStore',
+  'resource:///modules/sessionstore/SessionStore.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'Task',
+  'resource://gre/modules/Task.jsm');
+
+const EXPORTED_SYMBOLS = ['PlacesSearch']; // eslint-disable-line no-unused-vars
+
+
+function PlacesSearch() {}
+PlacesSearch.prototype = {
+
+  // This function returns the base history query used by the existing
+  // autocomplete code. Given an optional SQL query fragment (`conditions`),
+  // which we don't currently use, return a SQL query which fetches fuzzy
+  // matches from the Places DB, sorted in frecency order.
+  //
+  // Because we're reusing the current base query, this function documents
+  // some facts about the current search behavior that are either undocumented
+  // or sparsely documented across lots of files.
+  //
+  // Frecency is a decaying measure of frequency + recency of visits to a URL.
+  // It is an integer >= 0, with no maximum value. Its value is roughly:
+  //   frecency = (visit_count * visit_type) for the 10 most recent visits,
+  // where visit_type is based on whether the URL was typed, clicked, etc. The
+  // detailed weighting behavior is defined in nsNavHistory, and is driven by a
+  // huge number of configurable preferences given there.
+  //
+  // Frecency decays by 0.975 per day, so that the value for a given site drops
+  // by half if the page is not visited for 28 days. nsNavHistory::DecayFrecency
+  // contains the implementation and additional details.
+  //
+  // See also MDN: https://mdn.io/Frecency_algorithm.
+  //
+  // The actual frecency calculation is in components/places/SQLFunctions.cpp.
+  //
+  // AUTOCOMPLETE_MATCH is a sqlite function, also defined in SQLFunctions.cpp.
+  defaultQuery: function(conditions = '') {
+    // Start by defining some constants used in the search:
+
+    // This constant corresponds to the :query_type variable, which could take
+    // any of these values:
+    //   - QUERYTYPE_FILTERED, used by the main search query and adaptive query
+    //   - QUERYTYPE_AUTOFILL_HOST, used for urlbar autofill of domain names,
+    //   - QUERYTYPE_AUTOFILL_URL, used for urlbar autofill of complete urls.
+    // QUERYTYPE_FILTERED seems like a good choice, since we're not (currently)
+    // concerned with autofilling the urlbar.
+    // This constant is defined in UnifiedComplete.js, not in any interface, so
+    // we'll just assign its numeric value directly here.
+    const QUERY_TYPE = 0; // QUERYTYPE_FILTERED
+
+    // This constant corresponds to the :matchBehavior variable, which is passed
+    // to the AUTOCOMPLETE_MATCH function.
+    //   - It specifies where to match within a searchable term: anywhere, at
+    //     the beginning of the term, on word boundaries within the term, or a
+    //     few other options.
+    //   - We use the default value, MATCH_BOUNDARY, which matches on word
+    //     boundaries within each searchable term.
+    //   - See the MATCH_* constants in mozIPlacesAutoComplete.idl for more.
+    const MATCH_BEHAVIOR = Ci.mozIPlacesAutoComplete.MATCH_BOUNDARY;
+
+    // This constant corresponds to the :searchBehavior variable, also passed to
+    // the AUTOCOMPLETE_MATCH function. Unlike matchBehavior, we construct this
+    // value by adding up options, C-style (that is, via bitwise OR).
+    //   - It specifies which fields to search out of history, bookmarks, tags,
+    //     page titles, page URLs, typed pages, javascript: URLs, currently-open
+    //     pages, and whether to include search suggestions.
+    //   - It also specifies whether to use the union or intersection of places
+    //     fields for the 'restrict' case (not sure, but seems like this is used
+    //     to narrow searches where the input is an empty string).
+    //   - See the BEHAVIOR_* constants in mozIPlacesAutoComplete.idl for more.
+    //   - The behavior constants are bitwise OR-ed together; look at how
+    //     store._defaultBehavior is constructed in UnifiedComplete.js.
+    //     In particular, UnifiedComplete uses: HISTORY, BOOKMARK, OPENPAGE,
+    //     and TYPED.
+    //   - In our case, we want to search history, bookmarks, tags, page titles,
+    //     page URLs, and typed pages, but not javascript URLs, currently-open
+    //     pages (because, unlike the existing code, we don't track open tabs
+    //     in a SQLite temp table--we use a simpler approach, see isOpen below),
+    //     or search suggestions (because we separately query the search
+    //     suggestion service). So, the correct value is constructed by taking
+    //     the bitwise OR of those BEHAVIOR_* constants.
+    const mp = Ci.mozIPlacesAutoComplete;
+    const SEARCH_BEHAVIOR = mp.BEHAVIOR_HISTORY | mp.BEHAVIOR_BOOKMARK |
+                            mp.BEHAVIOR_TAG | mp.BEHAVIOR_TITLE |
+                            mp.BEHAVIOR_URL | mp.BEHAVIOR_TYPED;
+
+    // This subquery can't be omitted: it yields several booleans that we have
+    // to pass to the AUTOCOMPLETE_MATCH function, namely, 'bookmarked', 'tags',
+    // and 'btitle'.
+    const SQL_BOOKMARK_TAGS_FRAGMENT =
+      `EXISTS(SELECT 1 FROM moz_bookmarks WHERE fk = h.id) AS bookmarked,
+       ( SELECT title FROM moz_bookmarks WHERE fk = h.id AND title NOTNULL
+         ORDER BY lastModified DESC LIMIT 1
+       ) AS btitle,
+       ( SELECT GROUP_CONCAT(t.title, ', ')
+         FROM moz_bookmarks b
+         JOIN moz_bookmarks t ON t.id = +b.parent AND t.parent = :parent
+         WHERE b.fk = h.id
+       ) AS tags`;
+
+    // TODO: t.open_count isn't available, because we don't count open pages
+    //       as part of our query (see discussion above), so we set it to zero
+    //       in the AUTOCOMPLETE_MATCH call below. It's not clear yet how this
+    //       change will impact results.
+    const query =
+      `SELECT ${QUERY_TYPE}, h.url, h.title, f.url, ${SQL_BOOKMARK_TAGS_FRAGMENT},
+              h.visit_count, h.typed, h.id, h.frecency
+       FROM moz_places h
+       LEFT JOIN moz_favicons f ON f.id = h.favicon_id
+       WHERE h.frecency <> 0
+         AND AUTOCOMPLETE_MATCH(:searchString, h.url,
+                                IFNULL(btitle, h.title), tags,
+                                h.visit_count, h.typed,
+                                bookmarked, /* t.open_count, */ 0,
+                                ${MATCH_BEHAVIOR}, ${SEARCH_BEHAVIOR})
+         ${conditions}
+       ORDER BY h.frecency DESC, h.id DESC
+       LIMIT :maxResults`;
+    return query;
+  },
+
+  // Check whether a given URL is already an open tab.
+  //
+  // If anything goes wrong, return a falsy value.
+  //
+  // Note: we don't currently attempt to canonicalize the urls in any way, so we
+  // might see false negatives due to variants like http vs https, www vs no www,
+  // query strings, or hashes.
+  isOpen: function(url) {
+    const openUrls = [];
+    let browserState;
+
+    // Get a list of all open tabs from nsSessionStore, then look for the specified
+    // url in the list.
+    // If anything goes wrong with parsing the browser state JSON, just give up
+    // and return a falsy value.
+    try {
+      browserState = JSON.parse(SessionStore.getBrowserState());
+    } catch (ex) {} // eslint-disable-line
+
+    if (!browserState) {
+      return;
+    }
+
+    // Iterate over open windows, and open tabs in each window, and grab the
+    // first URL in each tab entry. I assume other entries listings would
+    // correspond to iframes or frames, neither of which we care about.
+    browserState.windows.forEach((w) => {
+      w.tabs.forEach((t) => {
+        openUrls.push(t.entries[0].url);
+      });
+    });
+
+    return openUrls.indexOf(url) > -1;
+  },
+
+  // Public search API
+  //
+  // This is a first naive implementation of a search function. Returns a
+  // Promise that resolves to a list of results (or an empty list, if there
+  // are no results).
+  //
+  // Given a search string, query Places for matching visits, sort by frecency.
+  // Then convert into JSON objects ready for serialization, and resolve Task.
+  //
+  // TODO: Manage debouncing user input and canceling requests in flight (#144)
+  search: Task.async(function* (searchString) {
+    // TODO: Do we want to pool and reuse connections? This code grabs a new
+    // connection with every keystroke (#146).
+    const db = yield PlacesUtils.promiseDBConnection();
+
+    const query = this.defaultQuery();
+    const params = {
+      searchString: searchString,
+      maxResults: 20
+    };
+
+    const results = yield db.execute(query, params);
+
+    const converted = yield this._processResults(results);
+
+    // TODO: We put the search term inside each item only because it matches
+    // the existing API. Would make much more sense to put this top level in
+    // the final message packet (#145).
+    converted.forEach((r) => { r.text = searchString; });
+
+    return yield converted;
+  }),
+
+  _processResults: Task.async(function* (results) {
+    const processed = [];
+    for (let i = 0, item; i < results.length; i++) {
+      item = yield this._processRow(results[i]);
+      processed.push(item);
+    }
+    return yield processed;
+  }),
+
+  _processRow: Task.async(function* (row) {
+    // Rows we are not including, because the front-end doesn't need them:
+    //   queryType:  row.getResultByIndex(0), // see QUERY_TYPE docs above
+    //   visitCount: row.getResultByIndex(7),
+    //   id:         row.getResultByIndex(9), // moz_places URL id
+    //   typed:      !!row.getResultByIndex(8), // was it typed by the user
+    const result = {
+      url:        row.getResultByIndex(1),
+      title:      row.getResultByIndex(2),
+      // 'image' is the favicon url; we separately send the favicon file
+      // if it's found in the cache.
+      image: row.getResultByIndex(3),
+      frecency:   row.getResultByIndex(10)
+    };
+
+    // If the page is bookmarked, append a bookmark object to the result.
+    result.bookmark = null;
+    if (row.getResultByIndex(4)) {
+      result.bookmark = {
+        title: row.getResultByIndex(5),
+        tags: row.getResultByIndex(6)
+      };
+    }
+
+    // 'open' means: is it a currently-open window?
+    // We can use this in place of the moz-action:'switchtotab' URLs that we
+    // previously got from the Gecko autocomplete controller.
+    result.open = this.isOpen(result.url);
+
+    // 'type' is a legacy thing from the old autocomplete code, used for
+    // styling results. Not sure if we should keep it forever, but for now,
+    // keep a simplified version of the logic.
+    result.type = result.open ? 'action' :
+                    result.bookmarked ? 'bookmark' : 'favicon';
+
+    // If the favicon image is in the browser cache, append it in data URI
+    // Base64-encoded form, ready to be set as the src of an img element.
+    result.imageData = null;
+    try {
+      // `promiseFaviconData` rejects if no favicon data is found, and `yield`
+      // converts it to an Error.
+      const faviconData = yield PlacesUtils.promiseFaviconData(result.url);
+      result.imageData = 'data:' + faviconData.mimeType + ';base64,' +
+                         btoa(faviconData.data);
+    } catch (ex) {} // eslint-disable-line
+
+    return yield result;
+  }),
+
+  shutdown: function() {
+    // TODO: tear down db connection, cancel anything in flight (#146)
+  }
+};

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -59,6 +59,7 @@ const loadIntoWindow = function(win) {
   Cu.import('chrome://universalsearch-lib/content/Transport.js', app);
   Cu.import('chrome://universalsearch-lib/content/ui/Popup.js', app);
   Cu.import('chrome://universalsearch-lib/content/ui/Urlbar.js', app);
+  Cu.import('chrome://universalsearch-lib/content/PlacesSearch.js', app);
 
   // load the CSS into the document. not using the stylesheet service.
   const stylesheet = document.createElementNS('http://www.w3.org/1999/xhtml', 'h:link');
@@ -70,7 +71,7 @@ const loadIntoWindow = function(win) {
 
   // constructor injection of app global for non-UI classes, as needed
   app.broker = new app.Broker();
-
+  app.placesSearch = new app.PlacesSearch();
   app.transport = new app.Transport(app);
   app.transport.init();
 
@@ -103,6 +104,7 @@ const unloadFromWindow = function(win) {
   app.popup.remove();
 
   app.transport.shutdown();
+  app.placesSearch.shutdown();
   app.broker.shutdown();
 
   // show the search bar, if it was visible originally
@@ -118,6 +120,7 @@ const unloadFromWindow = function(win) {
   Cu.unload('chrome://universalsearch-lib/content/Transport.js', app);
   Cu.unload('chrome://universalsearch-lib/content/ui/Popup.js', app);
   Cu.unload('chrome://universalsearch-lib/content/ui/Urlbar.js', app);
+  Cu.unload('chrome://universalsearch-lib/content/PlacesSearch.js', app);
 
   // delete any dangling refs
   delete win.US;


### PR DESCRIPTION
Include frecency and favicon image (as base64 data) in responses.

Fixes #133, fixes #140, fixes #139, fixes #143.

(Still need to please the linter and double-check that the fixed bugs are really fixed.)

@chuckharmston give it as much r? as seems reasonable :-)
