### PR TITLE
Fixes #19: Let the iframe change the popup height. Set default height…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ To work around this:
 
 ## Useful Snippets
 
+#### Simulating iframe events
+We use pubsub to mediate connections between the Transport and everything else.
+
+This means that faking an event from the iframe is easy, once you know the name and contents of the expected event.
+
+Find the complete list of events from either the docs/API.md file, or by grepping for '::' in the src directory.
+
+If you want to see an example event object, then uncomment the console.log inside `Transport.sendMessage`, trigger the event you care about, and you should be able to inspect the logged object inside the Browser Toolbox.
+
+Once you know the signal you want to simulate, you need a pointer to the broker, in order to fire a fake signal into the app. This is easy to do, because the app global is visible on the ChromeWindow. For instance, if you want to fire an `adjust-height` event, open up the Browser Toolbox and type this: `window.US.broker.publish('iframe::adjust-height', { height: 100 })`. The popup should look shorter next time you type something in the urlbar :-). If you want to instantly see the effect on the popup, pin it open (see the 'force the popup to stay open' snippet).
+
 #### Force the popup to stay open
 Note: By design, this only works on one window at a time.
   - Enable & open the Browser Toolkit (see [MDN docs](https://developer.mozilla.org/en-US/docs/Tools/Browser_Toolbox#Enabling_the_Browser_Toolbox), it's easy)
@@ -63,3 +74,4 @@ Note: By design, this only works on one window at a time.
   - Next time the popup opens, it'll stay open.
   - Set `window.US.popup.isPinned` to `false` when you're done - or just close the window.
   - Note: the Browser Toolkit slows performance down a lot. Close it if you don't need to actively debug stuff, and the iframe will be much snappier.
+

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,10 +12,12 @@ For each of these events, the general packet format is `{ type, data }`, where `
     * [`navigational-key`](#navigational-key)
     * [`printable-key`](#printable-key)
     * [`popupopen`](#popupopen)
+    * [`popupheight`](#popupheight)
     * [`popupclose`](#popupclose)
 * Content to Addon
   * [`autocomplete-url-clicked`](#autocomplete-url-clicked)
-  * [`url-selected`](url-selected)
+  * [`url-selected`](#url-selected)
+  * [`adjust-height`](#adjust-height)
 
 ---
 
@@ -110,6 +112,18 @@ This event is sent when the popup is about to open.
 
 Corresponds to XUL `popupshowing` event.
 
+### `popupheight`
+
+This event is sent when the popup is about to open (separately from the `popupopen` event), and after an `adjust-height` message has been received and acted on, confirming that the resize worked.
+
+The event contents are the integer height of the popup in pixels (note that the message just contains the integer, and not the 'px' unit).
+
+```
+{
+  height: integer pixel height of the popup
+}
+```
+
 ### `popupclose`
 
 This event is sent to the iframe when the popup is about to close.
@@ -171,6 +185,23 @@ If there is no selected item and the user has hit Enter, use the `empty` type. T
     result: the text contents of the item selected by the user, could be a
             search suggestion or a url
     resultType: 'suggestion' or 'url' or 'empty'
+  }
+}
+```
+
+### `adjust-height`
+
+This event should be sent when the iframe wants to change the height of its container.
+
+After setting the height, the addon will wait a turn, then send back a `popupheight` event, so the iframe can confirm the resize worked.
+
+The `popupheight` event is also sent each time the popup opens, so the iframe will know if it needs to request a height change.
+
+```
+{
+  type: 'adjust-height',
+  data: {
+    height: integer value for the new height
   }
 }
 ```

--- a/src/chrome/skin/binding.css
+++ b/src/chrome/skin/binding.css
@@ -1,5 +1,11 @@
 #PopupAutoCompleteRichResultUnivSearch {
+  /* This odd CSS property connects an XBL file with XUL DOM.
+   * See mdn.io/moz-binding for more.
+   */
   -moz-binding: url("chrome://universalsearch/content/content.xml#autocomplete-rich-result-popup-univ-search");
-  min-height: 303px;
+
+  /* Setting a sane lower limit here; we'll use JS to set default height. */
+  min-height: 20px;
+
   overflow: hidden;
 }

--- a/src/lib/Transport.js
+++ b/src/lib/Transport.js
@@ -42,6 +42,7 @@ Transport.prototype = {
     this.app.broker.subscribe('popup::autocompleteSearchResults',
                                this.onAutocompleteSearchResults, this);
     this.app.broker.subscribe('popup::popupClose', this.onPopupClose, this);
+    this.app.broker.subscribe('popup::popupHeight', this.onPopupHeight, this);
     this.app.broker.subscribe('popup::popupOpen', this.onPopupOpen, this);
     this.app.broker.subscribe('popup::suggestedSearchResults',
                                this.onSuggestedSearchResults, this);
@@ -62,6 +63,7 @@ Transport.prototype = {
     this.app.broker.unsubscribe('popup::autocompleteSearchResults',
                                  this.onAutocompleteSearchResults, this);
     this.app.broker.unsubscribe('popup::popupClose', this.onPopupClose, this);
+    this.app.broker.unsubscribe('popup::popupHeight', this.onPopupHeight, this);
     this.app.broker.unsubscribe('popup::popupOpen', this.onPopupOpen, this);
     this.app.broker.unsubscribe('popup::suggestedSearchResults',
                                  this.onSuggestedSearchResults, this);
@@ -103,6 +105,9 @@ Transport.prototype = {
   onPrintableKey: function(msg) {
     this.sendMessage('printable-key', msg);
   },
+  onPopupHeight: function(msg) {
+    this.sendMessage('popupheight', msg);
+  },
   onPopupOpen: function(msg) {
     this.sendMessage('popupopen');
   },
@@ -114,7 +119,8 @@ Transport.prototype = {
       type: evt,
       data: data || null
     };
-    console.log('sending the ' + evt + ' message to content:' + JSON.stringify(msg));
+    // Super helpful for debugging:
+    // console.log('sending the ' + evt + ' message to content:' + JSON.stringify(msg));
     const ctx = {
       browser: this.app.browser,
       principal: Cc['@mozilla.org/systemprincipal;1']


### PR DESCRIPTION
… using JS, not CSS.
- Introduce and document new `popupheight` and `adjust-height` signals.
- Since we accidentally committed some debugging console.log code inside
  Transport, document how to use the logged signals to fire fake events
  on the Broker.

@chuckharmston r? Should be mostly sane-looking JS code in this one. No worries if you're busy; I'm slowly building docs, and we can do a brain dump session at Mozlando.
