### PR TITLE
Speed things up by parallelizing searches and starting sooner.

### DIFF
--- a/src/chrome/content/content.xml
+++ b/src/chrome/content/content.xml
@@ -47,9 +47,8 @@
       <method name="_invalidate">
         <body>
           <![CDATA[
-            // The inherited method calls _appendCurrentResult and recalculates
-            // the richlistbox height. Override, removing the XUL DOM code.
-            this._appendCurrentResult();
+            // Override inherited method, which appends results to the
+            // richlistbox, then recalculates the richlistbox's height.
           ]]>
         </body>
       </method>
@@ -79,19 +78,7 @@
       <method name="_appendCurrentResult">
         <body>
           <![CDATA[
-            // We want to override this method with a method that runs in
-            // the more predictable, documented, and familiar JS+DOM
-            // environment. Oddly, we'll do this DOM Level 0 style, in the
-            // lib/ui/Popup render method, by assigning
-            // browser._appendCurrentResult to a JS-defined method.
-            //
-            // Because we don't want to override the method in the superclass,
-            // which is also the parent of the form field autocomplete UI, we
-            // create an _appendCurrentResult on our subclass by creating an
-            // empty no-op method here, on the XBL side. (Clearly there is a
-            // kind of prototypal inheritance at work, though exactly how it
-            // works is poorly documented, and XBL itself is an unspecified
-            // language.)
+            // Override yet another method with a no-op.
           ]]>
         </body>
       </method>

--- a/src/lib/Transport.js
+++ b/src/lib/Transport.js
@@ -31,8 +31,6 @@ function Transport(appGlobal) {
   this.port = null;
   // channelId must be unique to each window (#64)
   this.channelId = 'ohai-' + Math.floor(Math.random() * 100000);
-  this._lastAutocompleteSearchTerm = '';
-  this._lastSuggestedSearchTerm = '';
 }
 
 Transport.prototype = {
@@ -76,27 +74,10 @@ Transport.prototype = {
     if (id !== this.channelId) { return; }
     this.app.broker.publish('iframe::' + msg.type, msg.data);
   },
-  // Dedupe sequential messages if the user input hasn't changed. See #18 and
-  // associated commit message for gnarly details.
-  //
-  // Note, there is some duplication in the deduping logic in these two fns.
-  // However, I'm not sure the result of functional decomposition (extracting
-  // the dedupe function into a memoize-like combinator) would actually yield
-  // more understandable or readable code than what we've got here. :-\
   onAutocompleteSearchResults: function(msg) {
-    const currentInput = msg && msg.length && msg[0].text;
-    if (currentInput && currentInput === this._lastAutocompleteSearchTerm) {
-      return;
-    }
-    this._lastAutocompleteSearchTerm = currentInput;
     this.sendMessage('autocomplete-search-results', msg);
   },
   onSuggestedSearchResults: function(msg) {
-    const currentInput = msg && msg.term;
-    if (currentInput && currentInput === this._lastSuggestedSearchTerm) {
-      return;
-    }
-    this._lastSuggestedSearchTerm = currentInput;
     this.sendMessage('suggested-search-results', { results: msg });
   },
   onNavigationalKey: function(msg) {


### PR DESCRIPTION
@chuckharmston @nchapman Check this out, it's awesome!

I did some experimenting with the User Timing APIs tonight. I instrumented current master over here: https://github.com/6a68/universal-search-addon/commit/054ab7602f6bce3c19f5e3d2b8685647a2f6aeb5 and, typing a single letter into the urlbar, I noticed a super long delay between the keydown and XUL invoking the method we have been using to kick off the searches:

![](https://www.dropbox.com/s/ljj6a5j719k8gze/Screenshot%202015-12-03%2016.53.32.png?dl=0&raw=true)

Also, it's not shown in that particular example, but I found that the search suggestions latency often tended to be much greater than the places search latency (like, ~200 msec vs ~50 msec). I also found, interestingly, that if I typed quickly, the popup wouldn't start the searches until all the typing had stopped. In our case, we want to kick off a search immediately with the first key, otherwise you wind up with a flicker of an empty, very short popup--because the popup opens when the first keypress happens. In cases where I typed quickly, the "waiting for user to stop typing" delay was by far the largest contributor to latency. Interface engineering is hard.

OK, so, on to the good news! See below for the commit message with tons of gory detail, but basically, I:
- parallelized the places and search suggestions searches via `Promise.all`
- stopped relying on `_appendCurrentResult`, instead kicking off a search as soon as the first keydown happens, making our code much simpler and _much_ faster
- only ever get the search term from the XUL DOM once: the urlbar gets the keys, puts them in a signal, and the searches use the string from the signal, where they were formerly getting them from XUL or an XPCOM controller.

What's the result? It is zomg super snappy, and here's what the perf timing numbers looked like in a random single-character input:

![](https://www.dropbox.com/s/8dfj0e4vs4dypp8/Screenshot%202015-12-03%2020.04.53.png?dl=0&raw=true)

Now, when the popup opens, the only flicker I see is due to the tiny machine result jumping in slightly late. Fucking awesome!

I'm going to get a patch together, later, with the perf timing stuff integrated in a nice, clean way. For now, I'm leaving it out.

Here's the original commit message with more low-level detail:

---

We originally hooked into the existing code's UI updating routing by
overriding _appendCurrentResult on the XBL popup. However, abandoning
this approach makes life so, so much better:
- Because _appendCurrentResult is intended to add a row to a list, it
  gets called many times for a given query--which led to duplicate
  signals being sent to the iframe, causing flickery jank. To hack
  around this bug, some nasty duplicate event checking was added to the
  Transport, but that duplicate checking sometimes causes bugs of its
  own (say, if you type 'g', delete it, then type 'g' again). By
  listening for key events instead, these layers of hacks can finally be
  removed (yay!).
- It seems that _appendCurrentResult is only invoked after the user has
  totally stopped typing. But, for better perceived performance, we want
  to immediately kick off a search as soon as we get the first printable
  key. To do that, the popup now listens for the urlbar's printable-key
  event, which is fired as soon as a printable key is pressed.
- Rather than run the places and suggestions searches in series, we now
  run them in parallel.
- We also now pass the search term to the places and suggestions fns
  via the urlbar event, to avoid repeatedly touching the XUL DOM to get
  the search string. Because Promise.all rejects if either of the
    promises rejects, update error handling in the search suggestion code,
    and simplify it while we're in there.
