### PR TITLE
Update eslint-config-universal-search version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,12 @@
-extends: universal-search
+extends: universal-search/addon
+
+ecmaFeatures:
+  generators: true
 
 rules:
-  consistent-return: 0
+  func-names: 0
   no-console: 0
-  no-var: 2
-  prefer-const: 2
+  no-nested-ternary: 1
+  no-param-reassign: 1
+  object-shorthand: 0
+  space-before-function-paren: [2, never]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,18 +7,18 @@ const zip = require('gulp-zip');
 const pkgVersion = require('./package.json').version;
 
 // Delete everything in the `dist/*` directory.
-gulp.task('clean:dist', function (callback) {
+gulp.task('clean:dist', function(callback) {
   del(['dist'], callback);
 });
 
 // Copy the `src/*.rdf` files to `dist/*.rdf` for easier deployment.
-gulp.task('copy:rdf', ['generate:rdf'], function () {
+gulp.task('copy:rdf', ['generate:rdf'], function() {
   return gulp.src('src/*.rdf')
     .pipe(gulp.dest('dist'));
 });
 
 // Run ESLint against all the *.js files.
-gulp.task('eslint', function () {
+gulp.task('eslint', function() {
   return gulp.src('{,src/**/,test/**/}*.js')
     .pipe(eslint())
     .pipe(eslint.failOnError());
@@ -26,14 +26,14 @@ gulp.task('eslint', function () {
 
 // TODO: stop doing this templating for the rdf files. It's excessively complex.
 // Generate the `src/install.rdf` and `src/update.rdf` files from the templates.
-gulp.task('generate:rdf', function () {
+gulp.task('generate:rdf', function() {
   return gulp.src('templates/*.rdf')
-    .pipe(template({version: pkgVersion}))
+    .pipe(template({ version: pkgVersion }))
     .pipe(gulp.dest('src'));
 });
 
 // Generate the `dist/addon.xpi` file from the files in `src/**`.
-gulp.task('generate:xpi', function () {
+gulp.task('generate:xpi', function() {
   return gulp.src('src/**')
     .pipe(zip('addon.xpi'))
     .pipe(gulp.dest('dist'));

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   },
   "devDependencies": {
     "del": "1.2.0",
-    "eslint-config-universal-search": "2.0.0",
+    "eslint-config-airbnb": "3.0.1",
+    "eslint-config-universal-search": "3.0.0",
     "gulp": "3.9.0",
-    "gulp-eslint": "1.0.0",
+    "gulp-eslint": "1.1.1",
     "gulp-template": "3.0.0",
     "gulp-zip": "3.0.2",
     "husky": "0.9.1",

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -3,7 +3,7 @@
 /* global APP_SHUTDOWN, ADDON_DISABLE, ADDON_UNINSTALL, Components, Main,
           XPCOMUtils */
 
-const {utils: Cu} = Components;
+const { utils: Cu } = Components;
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'Main',

--- a/src/lib/PlacesSearch.js
+++ b/src/lib/PlacesSearch.js
@@ -31,7 +31,7 @@
 
 /* global Components, PlacesUtils, SessionStore, Task, XPCOMUtils */
 
-const {utils: Cu, interfaces: Ci, classes: Cc} = Components;
+const { utils: Cu, interfaces: Ci, classes: Cc } = Components;
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'console',
@@ -302,12 +302,12 @@ PlacesSearch.prototype = {
     //   id:         row.getResultByIndex(9), // moz_places URL id
     //   typed:      !!row.getResultByIndex(8), // was it typed by the user
     const result = {
-      url:        row.getResultByIndex(1),
-      title:      row.getResultByIndex(2),
+      url: row.getResultByIndex(1),
+      title: row.getResultByIndex(2),
       // 'image' is the favicon url; we separately send the favicon file
       // if it's found in the cache.
       image: row.getResultByIndex(3),
-      frecency:   row.getResultByIndex(10)
+      frecency: row.getResultByIndex(10)
     };
 
     // If the page is bookmarked, append a bookmark object to the result.

--- a/src/lib/Transport.js
+++ b/src/lib/Transport.js
@@ -7,7 +7,7 @@
 
 /* global Components, Services, WebChannel, XPCOMUtils */
 
-const {utils: Cu, interfaces: Ci, classes: Cc} = Components;
+const { utils: Cu, interfaces: Ci, classes: Cc } = Components;
 
 const EXPORTED_SYMBOLS = ['Transport']; // eslint-disable-line no-unused-vars
 

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -6,7 +6,7 @@
 
 /* global Components, CustomizableUI, Services, XPCOMUtils */
 
-const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+const { classes: Cc, interfaces: Ci, utils: Cu } = Components;
 
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'Services',
@@ -31,7 +31,7 @@ const loadIntoWindow = function(win) {
 
   // set the app global per-window
   if (win.US === undefined) {
-    Object.defineProperty(win, 'US', {configurable: true, value: {}});
+    Object.defineProperty(win, 'US', { configurable: true, value: {} });
   } else {
     win.US = win.US || {};
   }
@@ -88,7 +88,6 @@ const loadIntoWindow = function(win) {
   app.gBrowser.tabContainer.addEventListener('TabSelect', onTabSelect);
   app.gBrowser.tabContainer.addEventListener('TabOpen', onTabOpen);
   app.gBrowser.tabContainer.addEventListener('TabClose', onTabClose);
-
 };
 
 // basically reverse the loadIntoWindow function

--- a/src/lib/ui/Popup.js
+++ b/src/lib/ui/Popup.js
@@ -5,7 +5,7 @@
 /* global Components, PrivateBrowsingUtils, SearchSuggestionController,
           Services, Task, XPCOMUtils */
 
-const {utils: Cu, interfaces: Ci, classes: Cc} = Components;
+const { utils: Cu, interfaces: Ci, classes: Cc } = Components;
 
 const EXPORTED_SYMBOLS = ['Popup']; // eslint-disable-line no-unused-vars
 
@@ -108,8 +108,8 @@ Popup.prototype = {
   },
   handleEvent: function(evt) {
     const handlers = {
-      'popuphiding': this.onPopupHiding,
-      'popupshowing': this.onPopupShowing
+      popuphiding: this.onPopupHiding,
+      popupshowing: this.onPopupShowing
     };
     if (evt.type in handlers) {
       handlers[evt.type].call(this, evt);

--- a/src/lib/ui/Urlbar.js
+++ b/src/lib/ui/Urlbar.js
@@ -4,7 +4,7 @@
 
 /* global Components, PrivateBrowsingUtils, Services, XPCOMUtils */
 
-const {utils: Cu} = Components;
+const { utils: Cu } = Components;
 
 const EXPORTED_SYMBOLS = ['Urlbar']; // eslint-disable-line no-unused-vars
 
@@ -167,13 +167,13 @@ Urlbar.prototype = {
   },
   handleEvent: function(evt) {
     const handlers = {
-      'focus': this.onFocus,
-      'blur': this.onBlur,
-      'keydown': this.onKeyDown,
-      'keypress': this.onKeyPress,
-      'mousedown': this.onMouseDown,
-      'paste': this.onPaste,
-      'drop': this.onDrop
+      focus: this.onFocus,
+      blur: this.onBlur,
+      keydown: this.onKeyDown,
+      keypress: this.onKeyPress,
+      mousedown: this.onMouseDown,
+      paste: this.onPaste,
+      drop: this.onDrop
     };
     if (evt.type in handlers) {
       handlers[evt.type].call(this, evt);


### PR DESCRIPTION
OK, seems to pass locally for me, with a few hidden ESLint warnings.

If I run `npm run lint` directly, everything looks kosher with an exit code of `0` and no errors:

``` sh
$ npm run lint

> mozilla-universal-search-addon@5.1.4 lint /Users/pdehaan/dev/tmp/del/universal-search-addon
> gulp lint

[13:05:44] Using gulpfile ~/dev/tmp/del/universal-search-addon/gulpfile.js
[13:05:44] Starting 'eslint'...
[13:05:45] Finished 'eslint' after 901 ms
[13:05:45] Starting 'lint'...
[13:05:45] Finished 'lint' after 17 μs

$ echo $?
0
```

... But, if I run `eslint .` directly, I get 4 warnings (3x `no-param-reassign` and 1x `no-nested-ternary`), as seen below:

``` sh
$ ./node_modules/.bin/eslint .

/Users/pdehaan/dev/tmp/del/universal-search-addon/src/lib/main.js
  150:5   warning  Assignment to function parameter 'win'  no-param-reassign
  247:10  warning  Assignment to function parameter 'win'  no-param-reassign

/Users/pdehaan/dev/tmp/del/universal-search-addon/src/lib/PlacesSearch.js
  227:32  warning  Assignment to function parameter 'r'  no-param-reassign
  332:19  warning  Do not nest ternary expressions       no-nested-ternary

✖ 4 problems (0 errors, 4 warnings)

$ echo $?
0
```

---

**UPDATE:** Looks like we can force Gulp to display warnings and other ESLint output by specifying a formatter, like dis:

``` js
// Run ESLint against all the *.js files.
gulp.task('eslint', function() {
  return gulp.src('{,src/**/,test/**/}*.js')
    .pipe(eslint())
    .pipe(eslint.format()) // <---- note this glorious line
    .pipe(eslint.failOnError());
});
```
