### PR TITLE
Revert opengraph scraping merge from mozlando

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -54,10 +54,6 @@ result:
     tags: user-created tags, if any, for the bookmarked page
   }
   text: the search term in the address bar
-  fancyImageData: if we found a good image in the page, this is it as Base64
-                  data uri (or null)
-  description: if we found an opengraph or twitter description in the page,
-               it's passed as this key (or it'll be null)
 }
 ```
 

--- a/src/lib/PlacesSearch.js
+++ b/src/lib/PlacesSearch.js
@@ -29,7 +29,7 @@
 //   This corresponds to BOOKMARKED_HOST_QUERY and related constants in the
 //   existing code.
 
-/* global Components, PlacesUtils, Services, SessionStore, Task, XPCOMUtils */
+/* global Components, PlacesUtils, SessionStore, Task, XPCOMUtils */
 
 const {utils: Cu, interfaces: Ci, classes: Cc} = Components;
 
@@ -38,8 +38,6 @@ XPCOMUtils.defineLazyModuleGetter(this, 'console',
   'resource://gre/modules/devtools/Console.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'PlacesUtils',
   'resource://gre/modules/PlacesUtils.jsm');
-XPCOMUtils.defineLazyModuleGetter(this, 'Services',
-  'resource://gre/modules/Services.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'SessionStore',
   'resource:///modules/sessionstore/SessionStore.jsm');
 XPCOMUtils.defineLazyModuleGetter(this, 'Task',
@@ -342,16 +340,6 @@ PlacesSearch.prototype = {
       result.imageData = 'data:' + faviconData.mimeType + ';base64,' +
         this.base64EncodeString(faviconData.data);
     } catch (ex) {} // eslint-disable-line
-
-    // include fancy metadata (description or nice image), if we have them
-    const annos = PlacesUtils.getAnnotationsForURI(Services.io.newURI(result.url, null,null));
-    annos.forEach((anno) => {
-      if (anno.name === 'LOLZERS/imgDataUri') {
-        result.fancyImageData = anno.value;
-      } else if (anno.name === 'LOLZERS/description') {
-        result.description = anno.value;
-      }
-    });
 
     return yield result;
   }),


### PR DESCRIPTION
Our current top priority is improving performance, not adding more data.

Rather than leave this functional, but not performant, extra code in there, let's rip it out for now.

@chuckharmston r?

This reverts commit 5f353c58f1d10608f6a822d23b5b4eb37dcb7736, reversing
changes made to 1f8653661831e39f08de6f45c23ed83a6718492a.
